### PR TITLE
fix: Resolve extension crash on VS Code 1.101+ (issue #118)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -169,7 +169,7 @@ To add support for a new language:
 **CRITICAL Understanding for Copilot:**
 - **Task Success ≠ Completion:** When executing VS Code tasks via `run_task`, a "success" message indicates the task STARTED successfully, NOT that it completed
 - **Test Execution Time:** 
-  - "Test: Run All Tests" takes 3-4 minutes to complete (29 comprehensive tests)
+  - "Test: Run All Tests" takes 3-4 minutes to complete (52 comprehensive tests)
   - Other test suites take 20s-1.5 minutes depending on scope
 - **Status Interpretation:**
   - ✅ "Task succeeded with no problems" = Task started successfully
@@ -187,7 +187,7 @@ To add support for a new language:
 The project includes optimized VS Code tasks for efficient development. Access via `Ctrl/Cmd + Shift + P` → "Tasks: Run Task":
 
 #### Testing Tasks
-- **"Test: Run All Tests"** - Complete 29-test suite with compilation and linting (~2 min)
+- **"Test: Run All Tests"** - Complete 52-test suite with compilation and linting (~2 min)
 - **"Test: Configuration Suite Only"** - Configuration tests only (4 tests, ~20s)
 - **"Test: CSS nth-child Suite Only"** - CSS encoding tests only (2 tests, ~7s)  
 - **"Test: Keybinding Suite Only"** - Keyboard shortcut tests (2 tests, ~5s)
@@ -215,12 +215,12 @@ The project includes optimized VS Code tasks for efficient development. Access v
 
 **Pre-commit:**
 1. Build check: "Test: Compile and Build Only"
-2. Full validation: "Test: Run All Tests" (ensure 29/29 passing)
+2. Full validation: "Test: Run All Tests" (ensure 52/52 passing)
 
 ### Pre-Commit Testing
 - **CRITICAL**: Always run "Test: Run All Tests" before committing/pushing changes
 - **Validates**: TypeScript compilation, webpack build, ESLint rules, and all extension functionality
-- **Test Suite**: 29 comprehensive tests covering all minification scenarios and edge cases
+- **Test Suite**: 52 comprehensive tests covering all minification scenarios and edge cases
 - **Never commit**: Code that fails tests, has compilation errors, or doesn't pass linting
 
 ### Testing Strategy

--- a/.github/instructions/publish-update-extension.instructions.md
+++ b/.github/instructions/publish-update-extension.instructions.md
@@ -41,8 +41,12 @@ vsce login miguel-colmenares
    - **PATCH** (x.x.1): Bug fixes, small improvements
    - **MINOR** (x.1.x): New features, backward compatible
    - **MAJOR** (1.x.x): Breaking changes, architecture changes
-4. ✅ Update `CHANGELOG.md` with release date and changes
-5. ✅ Commit version changes: `git commit -m "chore: Release version X.X.X"`
+4. ✅ **Verify `engines.vscode` matches `@types/vscode`** in `package.json`:
+   - If `@types/vscode` is `^1.116.0`, then `engines.vscode` must also be `^1.116.0`
+   - Update `.vscode-test.mjs` default version accordingly
+   - Update `test-vscode-minimum.yml` workflow to test against the same version
+5. ✅ Update `CHANGELOG.md` with release date and changes
+6. ✅ Commit version changes: `git commit -m "chore: Release version X.X.X"`
 
 ### Step 2: Create Pull Request and Merge
 1. Create PR from feature branch to `master`
@@ -201,6 +205,8 @@ code --install-extension ./css-js-minifier-X.X.X.vsix
 ### Pre-Release
 - [ ] All features implemented and tested
 - [ ] Version number updated in package.json
+- [ ] `engines.vscode` matches `@types/vscode` version
+- [ ] `test-vscode-minimum.yml` and `.vscode-test.mjs` updated to match
 - [ ] CHANGELOG.md updated with release date
 - [ ] All tests passing (`npm test`)
 - [ ] Code linted successfully (`npm run lint`)

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -50,7 +50,7 @@ jobs:
             sleep 20
             npm test
         env:
-          VSCODE_VERSION: '1.110.0'
+          VSCODE_VERSION: '1.116.0'
           TEST_DELAY_MS: 3000
           MAX_RETRIES: 3
         timeout-minutes: 10

--- a/.github/workflows/test-vscode-minimum.yml
+++ b/.github/workflows/test-vscode-minimum.yml
@@ -1,4 +1,4 @@
-name: Test VS Code Minimum (1.110.0)
+name: Test VS Code Minimum (1.116.0)
 
 on:
   push:
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test-minimum:
-    name: Test on ${{ matrix.os }} with VS Code 1.110.0
+    name: Test on ${{ matrix.os }} with VS Code 1.116.0
     timeout-minutes: 10
     strategy:
       matrix:
@@ -41,7 +41,7 @@ jobs:
           node-version: 20
       - name: Install dependencies
         run: npm ci
-      - name: Run tests with VS Code 1.110.0 and rate limit handling
+      - name: Run tests with VS Code 1.116.0 and rate limit handling
         uses: coactions/setup-xvfb@v1
         with:
           run: |
@@ -49,7 +49,7 @@ jobs:
             sleep 20
             npm test
         env:
-          VSCODE_VERSION: '1.110.0'
+          VSCODE_VERSION: '1.116.0'
           TEST_DELAY_MS: 3000
           MAX_RETRIES: 3
         timeout-minutes: 10

--- a/.vscode-test.mjs
+++ b/.vscode-test.mjs
@@ -2,5 +2,5 @@ import { defineConfig } from '@vscode/test-cli';
 
 export default defineConfig({
 	files: 'out/test/**/*.test.js',
-	version: process.env.VSCODE_VERSION || '1.109.0',
+	version: process.env.VSCODE_VERSION || '1.116.0',
 });

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## [1.3.1] - 2026-04-28
+
+### Fixed
+
+- **Fix extension activation failure on VS Code 1.101+** ([#118](https://github.com/miguelcolmenares/css-js-minifier/issues/118))
+  - Updated `oxc-minify` from v0.124.0 to v0.128.0 to resolve `PendingMigrationError: navigator is now a global in nodejs`
+  - VS Code 1.101 introduced Electron 35 / Node.js 22 which adds `navigator` as a global, breaking extensions that use it for web environment detection
+
+### Added
+
+- **Output Channel for structured logging** ([#118](https://github.com/miguelcolmenares/css-js-minifier/issues/118))
+  - Extension now logs activation status to the "CSS & JS Minifier" Output panel
+  - Shows detailed error messages and stack traces when activation fails
+  - Users can diagnose issues via Output panel instead of silent failures
+
+### Changed
+
+- **Minimum VS Code version raised to 1.116.0** to match `@types/vscode` dependency
+- Updated `test-vscode-minimum` workflow to test against VS Code 1.116.0
+- Improved activation error handling with user-friendly messages directing to the Output panel
+
 ## [1.3.0] - 2026-04-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ Both minification engines are Rust-based, work fully offline, and require no API
 
 ## VS Code Compatibility Testing
 
-[![VS Code 1.109.0 Tests](https://img.shields.io/github/actions/workflow/status/miguelcolmenares/css-js-minifier/test-vscode-minimum.yml?style=flat-square&label=VS%20Code%201.109.0&logo=visual-studio-code&logoColor=white)](https://github.com/miguelcolmenares/css-js-minifier/actions/workflows/test-vscode-minimum.yml 'Minimum supported VS Code version - tested on all platforms')
+[![VS Code 1.116.0 Tests](https://img.shields.io/github/actions/workflow/status/miguelcolmenares/css-js-minifier/test-vscode-minimum.yml?style=flat-square&label=VS%20Code%201.116.0&logo=visual-studio-code&logoColor=white)](https://github.com/miguelcolmenares/css-js-minifier/actions/workflows/test-vscode-minimum.yml 'Minimum supported VS Code version - tested on all platforms')
 [![VS Code Stable Tests](https://img.shields.io/github/actions/workflow/status/miguelcolmenares/css-js-minifier/test-vscode-stable.yml?style=flat-square&label=VS%20Code%20Stable&logo=visual-studio-code&logoColor=white)](https://github.com/miguelcolmenares/css-js-minifier/actions/workflows/test-vscode-stable.yml 'Current stable VS Code version - tested on all platforms')
 [![VS Code Insiders Tests](https://img.shields.io/github/actions/workflow/status/miguelcolmenares/css-js-minifier/test-vscode-insiders.yml?style=flat-square&label=VS%20Code%20Insiders&logo=visual-studio-code&logoColor=white)](https://github.com/miguelcolmenares/css-js-minifier/actions/workflows/test-vscode-insiders.yml 'Pre-release VS Code version - tested on Ubuntu only')
 
 This extension is thoroughly tested across multiple VS Code versions to ensure compatibility:
 
-- **1.109.0 (Minimum)**: Engine requirement baseline - tested on macOS, Ubuntu, and Windows
+- **1.116.0 (Minimum)**: Engine requirement baseline - tested on macOS, Ubuntu, and Windows
 - **Stable**: Current production release - tested on all platforms
 - **Insiders**: Pre-release builds - tested on Ubuntu for early compatibility validation
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,4 +21,4 @@ This directory contains technical documentation for the CSS & JS Minifier VS Cod
 ---
 
 **Last Updated**: April 2026
-**Extension Version**: 1.3.0
+**Extension Version**: 1.3.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"license": "MIT",
 			"dependencies": {
 				"lightningcss": "^1.32.0",
-				"oxc-minify": "^0.127.0"
+				"oxc-minify": "^0.128.0"
 			},
 			"devDependencies": {
 				"@types/mocha": "^10.0.6",
@@ -182,9 +182,9 @@
 			}
 		},
 		"node_modules/@emnapi/core": {
-			"version": "1.9.2",
-			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-			"integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+			"integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -193,9 +193,9 @@
 			}
 		},
 		"node_modules/@emnapi/runtime": {
-			"version": "1.9.2",
-			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-			"integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+			"integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -578,9 +578,9 @@
 			}
 		},
 		"node_modules/@oxc-minify/binding-android-arm-eabi": {
-			"version": "0.127.0",
-			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-android-arm-eabi/-/binding-android-arm-eabi-0.127.0.tgz",
-			"integrity": "sha512-Nqv7JYcuQIH2faCuZWanGiMH9JDbBGXzeFg1XGX/KHDKcHP5yjWdMgDg0mKicO5Y7IfkpqZgGrsRAA7tnuhgSQ==",
+			"version": "0.128.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-android-arm-eabi/-/binding-android-arm-eabi-0.128.0.tgz",
+			"integrity": "sha512-EwdDhZLRmXxSnfy0v9gdOru7TutM8ItRg1Xv8e2B4boWMnHlFCIH38JfwgQnenbkF8SVTwVJtDCkmwEzN4q3xA==",
 			"cpu": [
 				"arm"
 			],
@@ -594,9 +594,9 @@
 			}
 		},
 		"node_modules/@oxc-minify/binding-android-arm64": {
-			"version": "0.127.0",
-			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-android-arm64/-/binding-android-arm64-0.127.0.tgz",
-			"integrity": "sha512-iCszKlx3On+e8occoIpvwFPPfqsb8lZBIpUUMWXiTq+7kT89eJbiT4YPT7v+R6RACKnyyyvtJGRjdXhEFm9Mhg==",
+			"version": "0.128.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-android-arm64/-/binding-android-arm64-0.128.0.tgz",
+			"integrity": "sha512-kwJ8YxWTzty8hD36jXxKiB+Po/ecmHZvT1xAYklkATbr0A4NUqV32sV+3Wfm8TecdA6jX34/mc+4CKK2+Hha2Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -610,9 +610,9 @@
 			}
 		},
 		"node_modules/@oxc-minify/binding-darwin-arm64": {
-			"version": "0.127.0",
-			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-darwin-arm64/-/binding-darwin-arm64-0.127.0.tgz",
-			"integrity": "sha512-WyrwCZh7ALq3G1ZEvODm+kDAaiBoxSUy7jsu42enGdetN/+kHPrURox1553iJRMmx2phZbpU9GNlkLQfMOR9gQ==",
+			"version": "0.128.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-darwin-arm64/-/binding-darwin-arm64-0.128.0.tgz",
+			"integrity": "sha512-WBV8j5EZ7/3rvFbiJ8LxowmobR/XH+l2iRzkE7zRYLD5VC+TvZayYGrVGGDXQvXm6cGED0B1NweByTmeT4lpGQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -626,9 +626,9 @@
 			}
 		},
 		"node_modules/@oxc-minify/binding-darwin-x64": {
-			"version": "0.127.0",
-			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-darwin-x64/-/binding-darwin-x64-0.127.0.tgz",
-			"integrity": "sha512-Zkuxqu43BI5+t86kpaAOqfRwv64OwDAYFMijiOsPB9XAxTaebigIyZmzL2yy7DSgNdwVsLnHNrlotFDw+LFsZw==",
+			"version": "0.128.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-darwin-x64/-/binding-darwin-x64-0.128.0.tgz",
+			"integrity": "sha512-U4k1CSBsY1uf6yHE+vCNJp0mHzjsUUXgOZXMyhRN3sE2ovBDT9Gl8oACmLWPjg0R68jwP+1vhnNPsSqpTEOycg==",
 			"cpu": [
 				"x64"
 			],
@@ -642,9 +642,9 @@
 			}
 		},
 		"node_modules/@oxc-minify/binding-freebsd-x64": {
-			"version": "0.127.0",
-			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-freebsd-x64/-/binding-freebsd-x64-0.127.0.tgz",
-			"integrity": "sha512-3tyfvXfNJ5NP3vsaM5PnOmnAR7dWM6Qivsnxrrfqx29VxZu99l+08dAAarnyyY+DXkw4qlPLxiygF26S9gqO5w==",
+			"version": "0.128.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-freebsd-x64/-/binding-freebsd-x64-0.128.0.tgz",
+			"integrity": "sha512-NT1GtcWpX4sOuU5dMdSNpdXJRpk9BGAHHnKc42IUId8E+jEhZUrg9vqIRIlspZG5O9Y7FjO2r6GBK93bpyIIUg==",
 			"cpu": [
 				"x64"
 			],
@@ -658,9 +658,9 @@
 			}
 		},
 		"node_modules/@oxc-minify/binding-linux-arm-gnueabihf": {
-			"version": "0.127.0",
-			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.127.0.tgz",
-			"integrity": "sha512-SvnlsgSzITSXYxqCRLC+sljje7s+bOvoblGVb6eVmtOYbDiYyNMv7n8IgKSSKNZpU/vv5qgfv/fSAHKQm/O+yA==",
+			"version": "0.128.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.128.0.tgz",
+			"integrity": "sha512-OskPMYMH2KtkqvRMULF2/+55hFo/qmRz2p/g7Cp7XNiqdjZ/DvQDiVbME63rVoX3dYjgS15DolGbo54mHTyA9w==",
 			"cpu": [
 				"arm"
 			],
@@ -674,9 +674,9 @@
 			}
 		},
 		"node_modules/@oxc-minify/binding-linux-arm-musleabihf": {
-			"version": "0.127.0",
-			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.127.0.tgz",
-			"integrity": "sha512-RB/g7T3oiibYwpPueO4bfGGwtzHZ6bq5AjoStKCeeo9q2B1iC3kftu/hKi0A+6iFgSiAWi7SfEUV6D9Nx4VLpw==",
+			"version": "0.128.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.128.0.tgz",
+			"integrity": "sha512-fKUY7Y1vb8CYlGnS5FzqTeeM5zQz1Fleyaqz/T9iNHYAYNJ0Os9iT0rACLfAVCQKP9yOqPSwZ80xgZdVVGD61w==",
 			"cpu": [
 				"arm"
 			],
@@ -690,9 +690,9 @@
 			}
 		},
 		"node_modules/@oxc-minify/binding-linux-arm64-gnu": {
-			"version": "0.127.0",
-			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.127.0.tgz",
-			"integrity": "sha512-Y1NcLMUWgJ4dH1oryOt/hstvjsYaIk5eePbNOFbkwInvCzguth2jaG6zO0kj74x3UjYyjj1kbWsUQQDflo4gbw==",
+			"version": "0.128.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.128.0.tgz",
+			"integrity": "sha512-T+CQQZ3BoWY/TxQk9LZsXZYj3madR/5tCErV6wzphTYZJfVjvKmQxnxMaT+TKE40Jha6+iGgwzxwcYWJfltULQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -706,9 +706,9 @@
 			}
 		},
 		"node_modules/@oxc-minify/binding-linux-arm64-musl": {
-			"version": "0.127.0",
-			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.127.0.tgz",
-			"integrity": "sha512-EVMGYld+Ca+NeaLymrnWo3rvbNVti9wqqvsnFZLPhrRpd5sL9GFLEUffg8En4GDl6CwtILJspoOVFL/mNDgbWQ==",
+			"version": "0.128.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.128.0.tgz",
+			"integrity": "sha512-F6RkJ90S1Xt25Mk7/wPUmddsE4RZ7Nei+HlEa2FAjfhpoaTciOwV6E/Gtp7wPIYbwft7UfhMYwuEuZiZQytVWw==",
 			"cpu": [
 				"arm64"
 			],
@@ -722,9 +722,9 @@
 			}
 		},
 		"node_modules/@oxc-minify/binding-linux-ppc64-gnu": {
-			"version": "0.127.0",
-			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.127.0.tgz",
-			"integrity": "sha512-gRAfy9iqrI2QP6j9XV40iCyelHdY59cYWE0cPn9N/bEBvVTYSks3tacxCZoVb+YsxuoYvag8JyVAaxujBK+j2Q==",
+			"version": "0.128.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.128.0.tgz",
+			"integrity": "sha512-0HP2FBGMlquLjShIIJvS4cebc6sdRRYL04GtxVpg96MtpejrkHYI2gQWcezsTUaGgg+eNRsuv2tdZPENu5+iWA==",
 			"cpu": [
 				"ppc64"
 			],
@@ -738,9 +738,9 @@
 			}
 		},
 		"node_modules/@oxc-minify/binding-linux-riscv64-gnu": {
-			"version": "0.127.0",
-			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.127.0.tgz",
-			"integrity": "sha512-3C1Oqslf10gFzuaBW5K63Vs72JNeSTFCRpbZKSFkd9F5xrNvtAAowhNEUv6dbetoM0DbsKxwH/1r8mrjyLUK0Q==",
+			"version": "0.128.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.128.0.tgz",
+			"integrity": "sha512-2j6Bd340IZqZbu4KUI28z87Ao9aHhq56HH1Qz5/+EdE732ajFYIoDF3z+QcxHXY0CFOG/Ur1ZOKTBEIWQ6BYIw==",
 			"cpu": [
 				"riscv64"
 			],
@@ -754,9 +754,9 @@
 			}
 		},
 		"node_modules/@oxc-minify/binding-linux-riscv64-musl": {
-			"version": "0.127.0",
-			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.127.0.tgz",
-			"integrity": "sha512-mKuBqbHLZIpiodCpfviUfGkz+xXfLZKL9/GXGuhWDIH6ICbxNmesuD94yB/DTAvqF7Kt0SuV3GeM7Hf+sT2rQQ==",
+			"version": "0.128.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.128.0.tgz",
+			"integrity": "sha512-z5HSppdxNwB6//3Eo7mDWbTrLeyuTKvL/iLXaKEgocrJg1MhZLbRR7P5ore9gKvS4lF4EtEpA24xzilFxQK0iw==",
 			"cpu": [
 				"riscv64"
 			],
@@ -770,9 +770,9 @@
 			}
 		},
 		"node_modules/@oxc-minify/binding-linux-s390x-gnu": {
-			"version": "0.127.0",
-			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.127.0.tgz",
-			"integrity": "sha512-MaciI97IVhGD1AVM5yB+jyEoJSk4bg2qu3g5qHQc/dYKgMFx1Wb7GHrTXLYY8cyjTpu2lOKVenoQANAGazuplg==",
+			"version": "0.128.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.128.0.tgz",
+			"integrity": "sha512-9rxYqH7P8NiYqRlLxlnNjJSF8BYADOmihM5ZHVkmlE4tqjHkoLNevdAyAP2ZBkL8QJflm1WGOXFWmFnWA54EvA==",
 			"cpu": [
 				"s390x"
 			],
@@ -786,9 +786,9 @@
 			}
 		},
 		"node_modules/@oxc-minify/binding-linux-x64-gnu": {
-			"version": "0.127.0",
-			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.127.0.tgz",
-			"integrity": "sha512-c8GW3zLzfIbx+k5V0ZO1cqq+LDoLnRlTHf5qWbXLYu+SXgLpnjjK9ig7pMCa1fFnKj29sJRcMP85q0/PxGmGGA==",
+			"version": "0.128.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.128.0.tgz",
+			"integrity": "sha512-sy5+4Oamw6Ly5gUNUIDQ7346Lryt7AhqjKhOtWl5dzYZnTIwwoI0V2DeIl3bR/vU8D629ZMYQOqhquRtSyBUOA==",
 			"cpu": [
 				"x64"
 			],
@@ -802,9 +802,9 @@
 			}
 		},
 		"node_modules/@oxc-minify/binding-linux-x64-musl": {
-			"version": "0.127.0",
-			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-x64-musl/-/binding-linux-x64-musl-0.127.0.tgz",
-			"integrity": "sha512-bHPjgV3TTfplFVXqgaaEZBtOeyqkuEE+OztqHl4AZ5FUuNwPTjCbn0ir/TsiBuy1F1o5Q4b/UJ86WojFO0qYCQ==",
+			"version": "0.128.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-x64-musl/-/binding-linux-x64-musl-0.128.0.tgz",
+			"integrity": "sha512-59Cxvjppy09TsaB15gr6rA9Bf87rm9t0bD1EW9dCZsdxWElnAC+TvWZ7v9dFUIeYeZUkhAAMPtpdqa3Y9CI2zA==",
 			"cpu": [
 				"x64"
 			],
@@ -818,9 +818,9 @@
 			}
 		},
 		"node_modules/@oxc-minify/binding-openharmony-arm64": {
-			"version": "0.127.0",
-			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-openharmony-arm64/-/binding-openharmony-arm64-0.127.0.tgz",
-			"integrity": "sha512-o7G4W7w32BQrfyc1wEMak0ROu4IdSsfYpnU5woAz3jkXvEEAPJtjFydt8ZdLBwo+QY9zrt6gi6s+e0P6DZOCeQ==",
+			"version": "0.128.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-openharmony-arm64/-/binding-openharmony-arm64-0.128.0.tgz",
+			"integrity": "sha512-XGa03zmiYpD7Kf1aXy6vjgkjfaCR90qH0TzGplnUXo6FF6gNe6sH9Zgneo9kxOyYt8CKKzXYD4VudT/nDTXq8Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -834,17 +834,17 @@
 			}
 		},
 		"node_modules/@oxc-minify/binding-wasm32-wasi": {
-			"version": "0.127.0",
-			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-wasm32-wasi/-/binding-wasm32-wasi-0.127.0.tgz",
-			"integrity": "sha512-RaVzU86yyUaRIGNPx+8uNZHy7rUWAA5cpdNSsln9Iu9pQrLZkmAlG6SvbEt6hy9OJ+YCQSqcmrIz3bbwhUXCOA==",
+			"version": "0.128.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-wasm32-wasi/-/binding-wasm32-wasi-0.128.0.tgz",
+			"integrity": "sha512-W+fK3cWhu/cUgx3NIAmDYcAyJs01aULlr3E3n/ZN79Q1/CX+FS+yWfwt/IysIi4FhpVL7z58azbJHDzhEx4X4g==",
 			"cpu": [
 				"wasm32"
 			],
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
-				"@emnapi/core": "1.9.2",
-				"@emnapi/runtime": "1.9.2",
+				"@emnapi/core": "1.10.0",
+				"@emnapi/runtime": "1.10.0",
 				"@napi-rs/wasm-runtime": "^1.1.4"
 			},
 			"engines": {
@@ -852,9 +852,9 @@
 			}
 		},
 		"node_modules/@oxc-minify/binding-win32-arm64-msvc": {
-			"version": "0.127.0",
-			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.127.0.tgz",
-			"integrity": "sha512-hKck5qLZAYu6ELCfqBI5ZPak3BI3BYSGurQtAwEhQlc65hp0yABOFkC/bWVXE+ZadfqwtL/Q1hwuAmTzB6YIPw==",
+			"version": "0.128.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.128.0.tgz",
+			"integrity": "sha512-pwMZd27FF+j4tHLYKtu4QBl6KI0gkt6xTNGLffs8VlH5vfDPHUvLo/AS6y66tdEjQ3chhs8OGg1mAFhPoQldDw==",
 			"cpu": [
 				"arm64"
 			],
@@ -868,9 +868,9 @@
 			}
 		},
 		"node_modules/@oxc-minify/binding-win32-ia32-msvc": {
-			"version": "0.127.0",
-			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.127.0.tgz",
-			"integrity": "sha512-bnfY+upjKaALeAYB5+r3WY62qW2vYT0hPU8DNYaqZTw5TMJrNlBk6VU4cvY00pelMdKcARAJznDyQ3KOx8/8HQ==",
+			"version": "0.128.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.128.0.tgz",
+			"integrity": "sha512-GskPdx/Fsn3ttkJbzxh51LYhla4N4p1sMufJKgf6PHupt5RukBaHI/GKM/2ni6ObxUI0b9UK37fROdV+5ekpMQ==",
 			"cpu": [
 				"ia32"
 			],
@@ -884,9 +884,9 @@
 			}
 		},
 		"node_modules/@oxc-minify/binding-win32-x64-msvc": {
-			"version": "0.127.0",
-			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.127.0.tgz",
-			"integrity": "sha512-hWyUPJ4QxHdMc7fwLY9IZMrppZ1IDLYJ9LdTH4kVpen76jyl48hqIDtbSF4Ci6rZYAmj5p9Rq+bjwZ3J+cw+HQ==",
+			"version": "0.128.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.128.0.tgz",
+			"integrity": "sha512-m8oakspZCbCod3WuY0U9DvwQlhMYaU31bK+Way1Rb+JGs455WLtkebEie/luSuN5DeF+aZyRH/zt1AY4weKQQg==",
 			"cpu": [
 				"x64"
 			],
@@ -4280,9 +4280,9 @@
 			}
 		},
 		"node_modules/oxc-minify": {
-			"version": "0.127.0",
-			"resolved": "https://registry.npmjs.org/oxc-minify/-/oxc-minify-0.127.0.tgz",
-			"integrity": "sha512-wrimObw3SzDvKccmPezJ3EAYXg3QVwuBZ54RJZ5YcKbwJ3NAl+QB2034Yvawo3m4CidE7D7soFD5/NIqKA1IOQ==",
+			"version": "0.128.0",
+			"resolved": "https://registry.npmjs.org/oxc-minify/-/oxc-minify-0.128.0.tgz",
+			"integrity": "sha512-VIXQO2W886aB+N17yV55Sack6aCpbUqtuNAYhNcPV6dFiWIZ5+kwOjvvw36igWwoljfjWhasu99CQ5wtvPJDYg==",
 			"license": "MIT",
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
@@ -4291,26 +4291,26 @@
 				"url": "https://github.com/sponsors/Boshen"
 			},
 			"optionalDependencies": {
-				"@oxc-minify/binding-android-arm-eabi": "0.127.0",
-				"@oxc-minify/binding-android-arm64": "0.127.0",
-				"@oxc-minify/binding-darwin-arm64": "0.127.0",
-				"@oxc-minify/binding-darwin-x64": "0.127.0",
-				"@oxc-minify/binding-freebsd-x64": "0.127.0",
-				"@oxc-minify/binding-linux-arm-gnueabihf": "0.127.0",
-				"@oxc-minify/binding-linux-arm-musleabihf": "0.127.0",
-				"@oxc-minify/binding-linux-arm64-gnu": "0.127.0",
-				"@oxc-minify/binding-linux-arm64-musl": "0.127.0",
-				"@oxc-minify/binding-linux-ppc64-gnu": "0.127.0",
-				"@oxc-minify/binding-linux-riscv64-gnu": "0.127.0",
-				"@oxc-minify/binding-linux-riscv64-musl": "0.127.0",
-				"@oxc-minify/binding-linux-s390x-gnu": "0.127.0",
-				"@oxc-minify/binding-linux-x64-gnu": "0.127.0",
-				"@oxc-minify/binding-linux-x64-musl": "0.127.0",
-				"@oxc-minify/binding-openharmony-arm64": "0.127.0",
-				"@oxc-minify/binding-wasm32-wasi": "0.127.0",
-				"@oxc-minify/binding-win32-arm64-msvc": "0.127.0",
-				"@oxc-minify/binding-win32-ia32-msvc": "0.127.0",
-				"@oxc-minify/binding-win32-x64-msvc": "0.127.0"
+				"@oxc-minify/binding-android-arm-eabi": "0.128.0",
+				"@oxc-minify/binding-android-arm64": "0.128.0",
+				"@oxc-minify/binding-darwin-arm64": "0.128.0",
+				"@oxc-minify/binding-darwin-x64": "0.128.0",
+				"@oxc-minify/binding-freebsd-x64": "0.128.0",
+				"@oxc-minify/binding-linux-arm-gnueabihf": "0.128.0",
+				"@oxc-minify/binding-linux-arm-musleabihf": "0.128.0",
+				"@oxc-minify/binding-linux-arm64-gnu": "0.128.0",
+				"@oxc-minify/binding-linux-arm64-musl": "0.128.0",
+				"@oxc-minify/binding-linux-ppc64-gnu": "0.128.0",
+				"@oxc-minify/binding-linux-riscv64-gnu": "0.128.0",
+				"@oxc-minify/binding-linux-riscv64-musl": "0.128.0",
+				"@oxc-minify/binding-linux-s390x-gnu": "0.128.0",
+				"@oxc-minify/binding-linux-x64-gnu": "0.128.0",
+				"@oxc-minify/binding-linux-x64-musl": "0.128.0",
+				"@oxc-minify/binding-openharmony-arm64": "0.128.0",
+				"@oxc-minify/binding-wasm32-wasi": "0.128.0",
+				"@oxc-minify/binding-win32-arm64-msvc": "0.128.0",
+				"@oxc-minify/binding-win32-ia32-msvc": "0.128.0",
+				"@oxc-minify/binding-win32-x64-msvc": "0.128.0"
 			}
 		},
 		"node_modules/p-limit": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "css-js-minifier",
 	"displayName": "JS & CSS Minifier Tool and Compressor",
 	"description": "Minify CSS and JS locally within Visual Studio Code. CSS uses LightningCSS and JS uses oxc-minify — both Rust-based, fully offline, with no API dependencies. Full support for modern CSS features like @starting-style. Supports 7 languages: English, Spanish, French, German, Portuguese, Japanese, and Chinese.",
-	"version": "1.3.0",
+	"version": "1.3.1",
 	"publisher": "miguel-colmenares",
 	"l10n": "./l10n",
 	"sponsor": {
@@ -19,7 +19,7 @@
 		"theme": "dark"
 	},
 	"engines": {
-		"vscode": "^1.110.0"
+		"vscode": "^1.116.0"
 	},
 	"categories": [
 		"Other"
@@ -196,6 +196,6 @@
 	},
 	"dependencies": {
 		"lightningcss": "^1.32.0",
-		"oxc-minify": "^0.127.0"
+		"oxc-minify": "^0.128.0"
 	}
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,7 +8,7 @@
  * minification and creating new minified files with configurable prefixes.
  *
  * @author Miguel Colmenares
- * @version 1.3.0
+ * @version 1.3.1
  * @since 0.1.0
  * @see {@link https://github.com/miguelcolmenares/css-js-minifier} GitHub Repository
  */
@@ -16,6 +16,12 @@
 import * as vscode from 'vscode';
 import { minifyCommand, minifyInNewFileCommand, onSaveMinify } from './commands';
 import { loadL10nBundle } from './utils/l10nHelper';
+
+/**
+ * Output channel for extension logging.
+ * Provides structured messages visible in the VS Code Output panel.
+ */
+let outputChannel: vscode.OutputChannel;
 
 /**
  * Activates the CSS & JS Minifier extension.
@@ -42,29 +48,47 @@ import { loadL10nBundle } from './utils/l10nHelper';
  * // - The user manually activates the extension
  */
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
-	// Initialize l10n fallback system
-	await loadL10nBundle(context.extensionPath);
+	// Create output channel for extension logging
+	outputChannel = vscode.window.createOutputChannel('CSS & JS Minifier');
+	context.subscriptions.push(outputChannel);
 
-	// Register the main minification command (in-place minification)
-	const minifyCommandDisposable = vscode.commands.registerCommand('extension.minify', minifyCommand);
+	try {
+		// Initialize l10n fallback system
+		await loadL10nBundle(context.extensionPath);
 
-	// Register the command for creating new minified files
-	const minifyInNewFileCommandDisposable = vscode.commands.registerCommand(
-		'extension.minifyInNewFile',
-		minifyInNewFileCommand
-	);
+		// Register the main minification command (in-place minification)
+		const minifyCommandDisposable = vscode.commands.registerCommand('extension.minify', minifyCommand);
 
-	// Add command disposables to context for proper cleanup on deactivation
-	context.subscriptions.push(minifyCommandDisposable);
-	context.subscriptions.push(minifyInNewFileCommandDisposable);
+		// Register the command for creating new minified files
+		const minifyInNewFileCommandDisposable = vscode.commands.registerCommand(
+			'extension.minifyInNewFile',
+			minifyInNewFileCommand
+		);
 
-	// Set up auto-minification on save if enabled in user settings
-	const config = vscode.workspace.getConfiguration('css-js-minifier');
-	if (config.get('minifyOnSave')) {
-		// Register event listener for document save events
-		const onSaveListener = vscode.workspace.onDidSaveTextDocument(onSaveMinify);
-		// Add listener to subscriptions for proper cleanup
-		context.subscriptions.push(onSaveListener);
+		// Add command disposables to context for proper cleanup on deactivation
+		context.subscriptions.push(minifyCommandDisposable);
+		context.subscriptions.push(minifyInNewFileCommandDisposable);
+
+		// Set up auto-minification on save if enabled in user settings
+		const config = vscode.workspace.getConfiguration('css-js-minifier');
+		if (config.get('minifyOnSave')) {
+			// Register event listener for document save events
+			const onSaveListener = vscode.workspace.onDidSaveTextDocument(onSaveMinify);
+			// Add listener to subscriptions for proper cleanup
+			context.subscriptions.push(onSaveListener);
+		}
+
+		outputChannel.appendLine('[INFO] CSS & JS Minifier extension activated successfully.');
+	} catch (error: unknown) {
+		const errorMessage = error instanceof Error ? error.message : String(error);
+		outputChannel.appendLine(`[ERROR] Extension activation failed: ${errorMessage}`);
+		if (error instanceof Error && error.stack) {
+			outputChannel.appendLine(`[ERROR] Stack trace: ${error.stack}`);
+		}
+		outputChannel.show(true);
+		vscode.window.showErrorMessage(
+			`CSS & JS Minifier failed to activate: ${errorMessage}. Check the Output panel for details.`
+		);
 	}
 }
 


### PR DESCRIPTION
## Description
Fixes extension crash caused by oxc-minify triggering `PendingMigrationError` on VS Code 1.101+ due to Node.js 22's `navigator` global.

## Changes
- Update `oxc-minify` from `^0.124.0` to `^0.128.0` (fixes PendingMigrationError)
- Add Output Channel (`CSS & JS Minifier`) for error visibility during activation
- Add try/catch error handling around extension activation
- Align `engines.vscode` with `@types/vscode` at `^1.116.0`
- Update `.vscode-test.mjs` and `test-vscode-minimum.yml` to match engine version
- Update documentation: README badge, CHANGELOG, copilot-instructions

## Testing
- [x] All 52 tests passing
- [x] ESLint passes with 0 errors
- [x] Webpack build succeeds
- [x] Version alignment verified (package.json, extension.ts, .vscode-test.mjs, workflow)

## Related Issues
Closes #118

## Checklist
- [x] Code follows project standards
- [x] Documentation updated
- [x] Tests pass
- [x] CHANGELOG updated