### PR TITLE
chore: Apply npm audit fix for HIGH severity Dependabot alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -264,9 +264,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@eslint/config-array/node_modules/brace-expansion": {
-			"version": "1.1.14",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"version": "1.1.16",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+			"integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1838,9 +1838,9 @@
 			"license": "ISC"
 		},
 		"node_modules/brace-expansion": {
-			"version": "5.0.6",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+			"integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2619,9 +2619,9 @@
 			"license": "MIT"
 		},
 		"node_modules/eslint/node_modules/brace-expansion": {
-			"version": "1.1.14",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"version": "1.1.16",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+			"integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2794,9 +2794,9 @@
 			"license": "MIT"
 		},
 		"node_modules/fast-uri": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-			"integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+			"integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
 			"dev": true,
 			"funding": [
 				{
@@ -2979,9 +2979,9 @@
 			"license": "MIT"
 		},
 		"node_modules/glob/node_modules/brace-expansion": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-			"integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+			"integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3755,9 +3755,9 @@
 			}
 		},
 		"node_modules/linkify-it": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
-			"integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+			"integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -4048,9 +4048,9 @@
 			"license": "MIT"
 		},
 		"node_modules/mocha/node_modules/brace-expansion": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-			"integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+			"integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {


### PR DESCRIPTION
## Purpose

Non-breaking `npm audit fix` to close the 6 open HIGH-severity Dependabot alerts on `master`. Only `package-lock.json` changes — no `package.json` update, no breaking major upgrades.

## Alerts Resolved (3 HIGH advisories = 6 Dependabot alerts across duplicate paths)

| Package | Advisory | Old → New |
|---|---|---|
| `fast-uri` | Host confusion via backslash / failed IDN canonicalization | → `3.1.3` / `3.1.4` |
| `linkify-it` | [GHSA-v245-v573-v5vm](https://github.com/advisories/GHSA-v245-v573-v5vm) — quadratic DoS via `mailto:` scan | → `5.0.2` |
| `brace-expansion` | DoS via exponential expansion of consecutive `{}` | → `1.1.16` / `2.1.2` / `5.0.7` |

All three are transitive **dev-scope** dependencies. Production bundle (`dist/extension.js` = `lightningcss` + `oxc-minify`, both Rust-based) is unaffected.

## Deferred

Remaining 3 LOW-severity alerts (`jsdiff` transitive via `mocha` via `@vscode/test-cli`) require breaking upgrade to `mocha@12` and are out of scope for this patch. Track in a separate PR when `@vscode/test-cli` releases a compatible major bump.

## Validation

- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npm run package` — webpack build success
- [x] `npm test` — **61 passing / 2 pending / 0 failing** (~39s)
- [x] `npm audit --audit-level=high` — **0 vulnerabilities**

## Diff Summary

```
 package-lock.json | 42 +++++++++++++++++++++---------------------
 1 file changed, 21 insertions(+), 21 deletions(-)
```