### PR TITLE
ci: Drop macOS from VS Code Insiders matrix (upstream darwin-arm64 bug)

### DIFF
--- a/.github/workflows/test-vscode-insiders.yml
+++ b/.github/workflows/test-vscode-insiders.yml
@@ -10,22 +10,36 @@ jobs:
   test-insiders:
     name: Test on ${{ matrix.os }} with VS Code Insiders
     timeout-minutes: 10
-    # macOS Insiders on darwin-arm64 currently fails to spawn Electron
-    # (ENOENT on `.../Visual Studio Code - Insiders.app/Contents/MacOS/Electron`).
-    # This is an upstream `@vscode/test-electron` compatibility gap with the
-    # renamed binary layout in recent Insiders builds; both `@vscode/test-cli`
-    # and `@vscode/test-electron` are already pinned to their latest published
-    # versions. The failure exists on `master` as well and is unrelated to any
-    # workspace code. Keep the job visible in the UI but prevent it from
-    # blocking PRs until the upstream fix ships.
-    continue-on-error: ${{ matrix.os == 'macos-latest' }}
     strategy:
       # Do not cancel the other OS jobs when one fails: the Insiders channel is
       # inherently unstable and a break on one platform is not evidence of a
       # regression on the others.
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        # macOS is intentionally excluded from the Insiders matrix.
+        #
+        # `@vscode/test-electron@3.0.0` fails to spawn Electron after
+        # downloading the darwin-arm64 Insiders archive (ENOENT on
+        # `Visual Studio Code - Insiders.app/Contents/MacOS/Electron`).
+        # See upstream bug: microsoft/vscode-test#348.
+        #
+        # We do NOT fall back to an Intel macOS runner (macos-15-intel /
+        # macos-13) as a workaround: Apple has fully transitioned off x86_64
+        # and macOS 26 (Tahoe) no longer supports Intel. Running the extension
+        # under Rosetta 2 on an arm64 host would test a code path that Apple
+        # is actively deprecating. `@vscode/test-cli` does not expose a
+        # `platform` override in its config, so a native arm64 fix requires
+        # the upstream bug to be resolved.
+        #
+        # macOS coverage is still exercised by the Stable and minimum-version
+        # workflows (both run on `macos-latest` arm64). Insiders drift
+        # specific to macOS is temporarily uncovered; the early-warning
+        # signal for VS Code API breakage remains via Ubuntu-Insiders and
+        # Windows-Insiders below.
+        #
+        # Restore `macos-latest` here once microsoft/vscode-test#348 is
+        # fixed and `@vscode/test-electron` is bumped to the fixed release.
+        os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
## Summary

Drop the `macos-latest` (Apple Silicon / arm64) cell from the VS Code Insiders test matrix as a temporary measure while [`microsoft/vscode-test#348`](https://github.com/microsoft/vscode-test/issues/348) is open upstream.

## Root Cause

`@vscode/test-electron@3.0.0` completes the download of the Insiders arm64 archive but then fails to spawn Electron:

```
✔ Downloaded VS Code (07b4ff1883f9…) into .vscode-test/vscode-darwin-arm64-insiders
✗ Test error: spawn .../vscode-darwin-arm64-insiders/Visual Studio Code - Insiders.app/Contents/MacOS/Electron ENOENT
```

The 340 MB `.zip` unpacks, but `insidersDownloadDirToExecutablePath()` (see [`lib/util.ts` in `microsoft/vscode-test`](https://github.com/microsoft/vscode-test/blob/main/lib/util.ts)) cannot locate the Electron binary inside the arm64 Insiders bundle.

- Not fixable by a version bump — both `@vscode/test-electron@3.0.0` and `@vscode/test-cli@0.0.15` are the latest published versions on npm.
- Not fixable via config — [`@vscode/test-cli`'s `IBaseTestConfiguration`](https://github.com/microsoft/vscode-test-cli/blob/main/src/config.cts) does not expose a `platform` override.
- Scoped bug — Ubuntu, Windows, and macOS **Stable** all pass on the same commit. Only `darwin-arm64` + `insiders` fails.

## Why Not Fall Back to an Intel macOS Runner

Apple has fully transitioned off x86_64. macOS 26 (Tahoe) drops Intel support entirely, and Rosetta 2 is a transitional compatibility layer that Apple has signaled will not persist long-term. Testing this extension under Rosetta on an Intel-labelled runner (`macos-15-intel`, or the already-retired `macos-13`) would validate a code path Apple itself is deprecating, and would not reflect what real users on Apple Silicon experience.

The correct fix must come from upstream `@vscode/test-electron` supporting `darwin-arm64` Insiders natively. Until then, skipping the broken cell is preferable to a fake-green `continue-on-error` guard or an Intel workaround.

## Change

```diff
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest]
```

Also removes the previous `continue-on-error` guard and replaces the comment block with a full explanation of the upstream bug, the arm64-first rationale, and the conditions under which macOS should be restored.

## Coverage Impact

**Retained**:
- Apple Silicon coverage of the extension on **Stable** VS Code (via [`test-vscode-stable.yml`](.github/workflows/test-vscode-stable.yml) on `macos-latest`).
- Apple Silicon coverage on the **minimum supported** version (via [`test-vscode-minimum.yml`](.github/workflows/test-vscode-minimum.yml) on `macos-latest`, VS Code 1.125.0).
- Apple Silicon build validation on **Build - Master** (on `macos-latest`).
- Insiders early-warning signal for upcoming VS Code API changes via **Ubuntu-Insiders** and **Windows-Insiders**.

**Temporarily lost**:
- macOS-specific Insiders API drift detection. This is rare in practice — VS Code's Insiders API changes are cross-platform.

## Testing

- Locally: `npm test` still passes (66/66) — this change is CI-config only, no source code touched.
- CI validation: this PR will exercise the trimmed Insiders matrix. Expected outcome: 2/2 Insiders cells green (Ubuntu, Windows).

## Follow-up

- Upstream bug tracked at [microsoft/vscode-test#348](https://github.com/microsoft/vscode-test/issues/348).
- When `@vscode/test-electron` ships a release fixing the `darwin-arm64` Insiders extraction/spawn path, restore `macos-latest` to this matrix.

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [x] 🔧 CI infrastructure (temporary skip while upstream bug is resolved)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No source code changed — CI-config only
- [x] Tests still pass locally
