### PR TITLE
fix(ci): Address post-merge Copilot review on PR #179

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,11 +56,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-        with:
-          # Full history is needed by `git rev-parse -q --verify refs/tags/…`
-          # in the tag-existence check below — otherwise the shallow clone
-          # would silently claim every tag is missing.
-          fetch-depth: 0
+        # A shallow clone (the default `fetch-depth: 1`) is enough here:
+        # the tag-existence check below uses `git ls-remote --tags` against
+        # origin, which never touches local history.
 
       - name: Setup Node.js
         uses: actions/setup-node@v7

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -14,7 +14,11 @@
 # Special cases that bypass the check:
 #   - Merge commits (Git prepends "Merge …")
 #   - Revert commits from `git revert` (start with "Revert ")
-#   - Automated release commits from workflows (start with "chore: Release ")
+#   - Fixup / squash commits (`fixup! …`, `squash! …`)
+#
+# Note: automated release commits (`chore: Release X.Y.Z`) already match the
+# Conventional Commits pattern below, so they are accepted by the regular
+# check — no special-case bypass is needed for them.
 #
 # Escape hatch: commit with `--no-verify` to skip locally. CI does not
 # re-check commit messages, so squash-and-merge lets maintainers rewrite


### PR DESCRIPTION
## Context

Copilot's automated review on PR #179 ran a **second pass** approximately 90 seconds after the squash-merge (16:03:50 UTC vs. merge at 16:02:27 UTC). That pass surfaced two additional docs/comment mismatches that we did not catch before merging. This PR fixes both.

## Changes

### 1. `.husky/commit-msg` — remove misleading bypass claim

The header comment listed `chore: Release …` as a **bypass case**, but the actual `case` statement only bypasses `Merge`, `Revert`, `fixup!`, and `squash!`. That mismatch invited a maintainer to 'fix the code' by adding an unnecessary bypass.

Reality: `chore: Release X.Y.Z` **already matches** the Conventional Commits regex naturally (`chore: <description>`), so it is accepted by the regular check. No bypass is needed. Comment corrected to reflect this.

### 2. `.github/workflows/release.yml` — drop unnecessary `fetch-depth: 0`

The preflight checkout requested a full-history clone with the justification that it was needed by a local `git rev-parse --verify refs/tags/…` check. But the actual check (originally line 114) uses:

```bash
git ls-remote --tags --exit-code origin "refs/tags/${tag}"
```

That queries the **remote** and needs zero local history. The deep fetch was a leftover from an earlier draft where the check was local. Dropping it shaves seconds off every preflight run with no functional change.

## Validation

- `actionlint .github/workflows/release.yml` — clean
- `js-yaml` structural parse — clean
- Regex self-test: `chore: Release 1.3.3` passes the Conventional Commits pattern ✓
- `npm run lint` — clean (no src/ changes)

## Related

- Follow-up to PR #179 (already merged).
- The two threads on PR #179 will be marked as resolved once this PR merges.