### PR TITLE
feat: Adopt TSDoc standard replacing JSDoc documentation comments

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -54,7 +54,7 @@ async function processDocument(document: vscode.TextDocument, options: MinifyOpt
 - **Code Reusability**: No duplicate validation or API logic
 - **Enhanced Testability**: Strategies can be mocked independently
 - **Improved Maintainability**: 63% reduction in main file size (220→81 lines)
-- **Better Documentation**: Comprehensive JSDoc with examples throughout
+- **Better Documentation**: Comprehensive TSDoc with examples throughout
 - **Extensibility**: Easy to add new strategies or swap implementations
 
 ### Configuration System
@@ -175,8 +175,8 @@ gh workflow run release.yml -f version=X.Y.Z
 ### Version Management & Documentation Standards
 **CRITICAL Version Update Requirements:**
 - **When changing version numbers:** Always update BOTH `package.json` AND `src/extension.ts`
-- **In `src/extension.ts`:** Update the `@version` line in the file header JSDoc comment
-- **For new functionality files:** Add `@since` comment ONLY in the file header JSDoc (not in individual functions)
+- **In `src/extension.ts`:** Update the `@version` line in the file header TSDoc comment
+- **For new functionality files:** Add `@since` comment ONLY in the file header TSDoc (not in individual functions)
 - **Example version update:**
   ```typescript
   /**
@@ -188,8 +188,8 @@ gh workflow run release.yml -f version=X.Y.Z
   ```
 
 **New File Documentation Standards:**
-- **Header JSDoc:** Include `@since` with the version when the file was created
-- **Function JSDoc:** Do NOT include `@since` in individual function documentation
+- **Header TSDoc:** Include `@since` with the version when the file was created
+- **Function TSDoc:** Do NOT include `@since` in individual function documentation
 - **Module exports:** Include comprehensive documentation with examples
 
 ### Task Execution Behavior (IMPORTANT)
@@ -318,10 +318,12 @@ const explorer = vscode.window.activeTextEditor?.document.uri;
 - **`src/*/index.ts`**: Module exports with documentation for each layer
 
 ### Documentation Standards
-- **Comprehensive JSDoc**: Every function has detailed documentation with examples
+- **TSDoc Standard**: All documentation comments follow the [TSDoc](https://tsdoc.org/) specification, enforced by `eslint-plugin-tsdoc`
+- **Comprehensive TSDoc**: Every function has detailed documentation with examples
 - **Type Safety**: Interfaces and types for all major data structures
 - **Error Handling**: Documented side effects and error conditions
 - **Usage Examples**: Practical code examples in documentation
+- **Custom Tags**: `@since`, `@version`, `@author` configured in `tsdoc.json`
 
 ## Testing & Debugging
 - Test files expect specific minified output (hardcoded in test file)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+### Changed
+
+- **Documentation**: Migrated all TypeScript doc comments from JSDoc to the [TSDoc](https://tsdoc.org/) standard ([#182](https://github.com/miguelcolmenares/css-js-minifier/issues/182))
+  - Removed redundant `{type}` annotations from `@param` and `@returns` (TypeScript provides these)
+  - Removed non-standard tags (`@fileoverview`, `@function`, `@async`, `@interface`, `@enum`, `@module`)
+  - Converted module-level docs to `@packageDocumentation`
+  - Moved `@sideEffects` content into `@remarks` sections
+  - Added `eslint-plugin-tsdoc` with `tsdoc/syntax: "error"` rule for CI enforcement
+  - Created `tsdoc.json` with custom modifier tags (`@since`, `@version`, `@author`)
+
 ## [1.3.3] - 2026-07-22
 
 ### Fixed

--- a/docs/tsdoc-adoption-plan.md
+++ b/docs/tsdoc-adoption-plan.md
@@ -1,0 +1,117 @@
+# TSDoc Adoption Plan — Issue #182
+
+## Problem Statement
+
+The project currently uses JSDoc-style documentation comments with several non-standard patterns that are incompatible with the TSDoc specification. This creates interoperability issues between tools (TypeDoc, API Extractor, VS Code IntelliSense) and introduces redundant type annotations that TypeScript already provides.
+
+## Current Architecture
+
+### Documentation Patterns in Use
+
+| File | Non-TSDoc Patterns Found |
+|------|--------------------------|
+| `src/extension.ts` | `@fileoverview`, `@author`, `@version`, `@since`, `@function`, `@param {type}`, `@returns {void}` |
+| `src/commands/minifyCommand.ts` | `@fileoverview`, `@author`, `@since`, `@async`, `@function`, `@param {type}`, `@returns {type}`, `@interface`, `@property {type}` |
+| `src/commands/index.ts` | `@fileoverview`, `@module` |
+| `src/services/minificationService.ts` | `@fileoverview`, `@author`, `@version`, `@since`, `@function`, `@param {type}`, `@returns {type}`, `@sideEffects` |
+| `src/services/fileService.ts` | `@async`, `@function`, `@param {type}`, `@returns {type}`, `@sideEffects` |
+| `src/services/strategies/localCssMinifier.ts` | `@fileoverview`, `@author`, `@version`, `@since`, `@function`, `@param {type}`, `@returns {type}`, `@sideEffects` |
+| `src/services/strategies/localJsMinifier.ts` | `@fileoverview`, `@author`, `@version`, `@since`, `@function`, `@param {type}`, `@returns {type}`, `@sideEffects` |
+| `src/services/strategies/index.ts` | `@fileoverview`, `@author`, `@version`, `@since` |
+| `src/services/index.ts` | `@fileoverview`, `@module`, `@since` |
+| `src/lib/constants.ts` | `@fileoverview`, `@author`, `@version`, `@since`, `@readonly` |
+| `src/lib/helpers.ts` | `@fileoverview`, `@author`, `@version`, `@since`, `@function`, `@param {type}`, `@returns {type}` |
+| `src/lib/index.ts` | `@fileoverview`, `@author`, `@version`, `@since` |
+| `src/types/minification.ts` | `@fileoverview`, `@author`, `@version`, `@since`, `@interface`, `@property {type}` |
+| `src/types/index.ts` | `@fileoverview`, `@author`, `@version`, `@since` |
+| `src/utils/validators.ts` | `@function`, `@param {type}`, `@returns {type}`, `@sideEffects`, `@readonly`, `@enum {string}` |
+| `src/utils/l10nHelper.ts` | `@fileoverview`, `@author`, `@since` |
+| `src/utils/index.ts` | `@fileoverview`, `@module` |
+
+### Violation Summary
+
+- **17 files** need migration
+- **~60 occurrences** of `{type}` annotations to remove
+- **~12 occurrences** of `@fileoverview` to convert
+- **~10 occurrences** of `@function` / `@async` to remove
+- **~6 occurrences** of `@sideEffects` to move into `@remarks`
+- **~5 occurrences** of `@interface` / `@property {type}` to remove
+
+## Proposed Changes
+
+### Tooling
+
+1. **Install** `eslint-plugin-tsdoc` (dev dependency)
+2. **Create** `tsdoc.json` at project root — define custom tags `@since`, `@version`, `@author` as modifier tags for backward compatibility with the project's version-tracking convention
+3. **Update** `eslint.config.mjs` — add `tsdoc` plugin with `tsdoc/syntax: "error"` rule for `src/**/*.ts` files
+
+### Comment Migration Rules
+
+| Action | Before | After |
+|--------|--------|-------|
+| Remove type braces | `@param {string} text - desc` | `@param text - desc` |
+| Remove type braces | `@returns {boolean} desc` | `@returns desc` |
+| Remove redundant tag | `@function functionName` | _(delete entirely)_ |
+| Remove redundant tag | `@async` | _(delete entirely)_ |
+| Remove redundant tag | `@interface InterfaceName` | _(delete entirely)_ |
+| Remove redundant tag | `@enum {string}` | _(delete entirely)_ |
+| Remove type braces | `@property {type} name - desc` | _(delete — TS handles it)_ |
+| Convert module doc | `@fileoverview desc` | `@packageDocumentation` + summary |
+| Move custom content | `@sideEffects\n- list` | Under `@remarks` heading |
+| Keep non-standard | `@module name` | _(delete — not TSDoc)_ |
+| Keep with custom def | `@since`, `@version`, `@author` | Keep — defined in `tsdoc.json` |
+| Keep standard | `@remarks`, `@example`, `@throws`, `@see`, `{@link}`, `@returns`, `@param` | Keep as-is |
+
+## Phase Breakdown
+
+### Phase 1: Tooling Setup (~15 min)
+
+1. `npm install --save-dev eslint-plugin-tsdoc`
+2. Create `tsdoc.json` with custom tag definitions
+3. Add `tsdoc` plugin + rule to `eslint.config.mjs`
+4. Run `npm run lint` to establish baseline violations
+
+### Phase 2: Core Module Migration (~30 min)
+
+Migrate in dependency order (leaves first):
+1. `src/types/minification.ts` + `src/types/index.ts`
+2. `src/lib/constants.ts` + `src/lib/helpers.ts` + `src/lib/index.ts`
+3. `src/utils/l10nHelper.ts` + `src/utils/validators.ts` + `src/utils/index.ts`
+
+### Phase 3: Service Layer Migration (~30 min)
+
+4. `src/services/strategies/localCssMinifier.ts`
+5. `src/services/strategies/localJsMinifier.ts`
+6. `src/services/strategies/index.ts`
+7. `src/services/minificationService.ts`
+8. `src/services/fileService.ts`
+9. `src/services/index.ts`
+
+### Phase 4: Command & Entry Point Migration (~20 min)
+
+10. `src/commands/minifyCommand.ts`
+11. `src/commands/index.ts`
+12. `src/extension.ts`
+
+### Phase 5: Validation & Docs (~15 min)
+
+13. Run full lint — zero warnings
+14. Run full test suite — all passing
+15. Update `AGENTS.md` documentation standards
+16. Update `.github/copilot-instructions.md` documentation section
+
+## Testing Strategy
+
+- **Lint validation**: `npm run lint` must produce 0 `tsdoc/syntax` errors
+- **Functional tests**: `npm test` must pass (52 tests) — doc changes are non-functional
+- **Manual verification**: Hover over symbols in VS Code to confirm IntelliSense renders correctly
+- **TSDoc Playground**: Spot-check complex comments at https://tsdoc.org/play/
+
+## Risk Assessment
+
+| Risk | Mitigation |
+|------|-----------|
+| Breaking IntelliSense | TSDoc is VS Code's native format — should improve |
+| Missing custom tags cause lint errors | `tsdoc.json` defines `@since`, `@version`, `@author` |
+| Tests fail unexpectedly | Tests don't depend on doc comments — purely cosmetic change |
+| Large diff hard to review | Split commits by phase for clear review |

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,6 +3,7 @@ import tsEslint from '@typescript-eslint/eslint-plugin';
 import tsParser from '@typescript-eslint/parser';
 import prettier from 'eslint-plugin-prettier';
 import prettierConfig from 'eslint-config-prettier';
+import tsdoc from 'eslint-plugin-tsdoc';
 
 export default [
 	js.configs.recommended,
@@ -50,10 +51,12 @@ export default [
 		plugins: {
 			'@typescript-eslint': tsEslint,
 			prettier: prettier,
+			tsdoc: tsdoc,
 		},
 		rules: {
 			...tsEslint.configs.recommended.rules,
 			'prettier/prettier': 'error',
+			'tsdoc/syntax': 'error',
 			'@typescript-eslint/naming-convention': [
 				'warn',
 				{
@@ -87,10 +90,12 @@ export default [
 		plugins: {
 			'@typescript-eslint': tsEslint,
 			prettier: prettier,
+			tsdoc: tsdoc,
 		},
 		rules: {
 			...tsEslint.configs.recommended.rules,
 			'prettier/prettier': 'error',
+			'tsdoc/syntax': 'off',
 			'@typescript-eslint/naming-convention': [
 				'warn',
 				{

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
 				"eslint": "^9.39.5",
 				"eslint-config-prettier": "^10.1.8",
 				"eslint-plugin-prettier": "^5.5.6",
+				"eslint-plugin-tsdoc": "^0.5.2",
 				"husky": "^9.1.7",
 				"mocha": "^11.7.6",
 				"prettier": "^3.9.5",
@@ -560,6 +561,50 @@
 				"@jridgewell/resolve-uri": "^3.1.0",
 				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
+		},
+		"node_modules/@microsoft/tsdoc": {
+			"version": "0.16.0",
+			"resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.16.0.tgz",
+			"integrity": "sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@microsoft/tsdoc-config": {
+			"version": "0.18.1",
+			"resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.18.1.tgz",
+			"integrity": "sha512-9brPoVdfN9k9g0dcWkFeA7IH9bbcttzDJlXvkf8b2OBzd5MueR1V2wkKBL0abn0otvmkHJC6aapBOTJDDeMCZg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@microsoft/tsdoc": "0.16.0",
+				"ajv": "~8.18.0",
+				"jju": "~1.4.0",
+				"resolve": "~1.22.2"
+			}
+		},
+		"node_modules/@microsoft/tsdoc-config/node_modules/ajv": {
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/@microsoft/tsdoc-config/node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@napi-rs/wasm-runtime": {
 			"version": "1.1.6",
@@ -2583,6 +2628,187 @@
 				}
 			}
 		},
+		"node_modules/eslint-plugin-tsdoc": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-tsdoc/-/eslint-plugin-tsdoc-0.5.2.tgz",
+			"integrity": "sha512-BlvqjWZdBJDIPO/YU3zcPCF23CvjYT3gyu63yo6b609NNV3D1b6zceAREy2xnweuBoDpZcLNuPyAUq9cvx6bbQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@microsoft/tsdoc": "0.16.0",
+				"@microsoft/tsdoc-config": "0.18.1",
+				"@typescript-eslint/utils": "~8.56.0"
+			}
+		},
+		"node_modules/eslint-plugin-tsdoc/node_modules/@typescript-eslint/project-service": {
+			"version": "8.56.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.56.1.tgz",
+			"integrity": "sha512-TAdqQTzHNNvlVFfR+hu2PDJrURiwKsUvxFn1M0h95BB8ah5jejas08jUWG4dBA68jDMI988IvtfdAI53JzEHOQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/tsconfig-utils": "^8.56.1",
+				"@typescript-eslint/types": "^8.56.1",
+				"debug": "^4.4.3"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.8.4 <6.0.0"
+			}
+		},
+		"node_modules/eslint-plugin-tsdoc/node_modules/@typescript-eslint/scope-manager": {
+			"version": "8.56.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.56.1.tgz",
+			"integrity": "sha512-YAi4VDKcIZp0O4tz/haYKhmIDZFEUPOreKbfdAN3SzUDMcPhJ8QI99xQXqX+HoUVq8cs85eRKnD+rne2UAnj2w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/types": "8.56.1",
+				"@typescript-eslint/visitor-keys": "8.56.1"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/eslint-plugin-tsdoc/node_modules/@typescript-eslint/tsconfig-utils": {
+			"version": "8.56.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.56.1.tgz",
+			"integrity": "sha512-qOtCYzKEeyr3aR9f28mPJqBty7+DBqsdd63eO0yyDwc6vgThj2UjWfJIcsFeSucYydqcuudMOprZ+x1SpF3ZuQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.8.4 <6.0.0"
+			}
+		},
+		"node_modules/eslint-plugin-tsdoc/node_modules/@typescript-eslint/types": {
+			"version": "8.56.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.56.1.tgz",
+			"integrity": "sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/eslint-plugin-tsdoc/node_modules/@typescript-eslint/typescript-estree": {
+			"version": "8.56.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.56.1.tgz",
+			"integrity": "sha512-qzUL1qgalIvKWAf9C1HpvBjif+Vm6rcT5wZd4VoMb9+Km3iS3Cv9DY6dMRMDtPnwRAFyAi7YXJpTIEXLvdfPxg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/project-service": "8.56.1",
+				"@typescript-eslint/tsconfig-utils": "8.56.1",
+				"@typescript-eslint/types": "8.56.1",
+				"@typescript-eslint/visitor-keys": "8.56.1",
+				"debug": "^4.4.3",
+				"minimatch": "^10.2.2",
+				"semver": "^7.7.3",
+				"tinyglobby": "^0.2.15",
+				"ts-api-utils": "^2.4.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.8.4 <6.0.0"
+			}
+		},
+		"node_modules/eslint-plugin-tsdoc/node_modules/@typescript-eslint/utils": {
+			"version": "8.56.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.56.1.tgz",
+			"integrity": "sha512-HPAVNIME3tABJ61siYlHzSWCGtOoeP2RTIaHXFMPqjrQKCGB9OgUVdiNgH7TJS2JNIQ5qQ4RsAUDuGaGme/KOA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@eslint-community/eslint-utils": "^4.9.1",
+				"@typescript-eslint/scope-manager": "8.56.1",
+				"@typescript-eslint/types": "8.56.1",
+				"@typescript-eslint/typescript-estree": "8.56.1"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+				"typescript": ">=4.8.4 <6.0.0"
+			}
+		},
+		"node_modules/eslint-plugin-tsdoc/node_modules/@typescript-eslint/visitor-keys": {
+			"version": "8.56.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.56.1.tgz",
+			"integrity": "sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/types": "8.56.1",
+				"eslint-visitor-keys": "^5.0.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/eslint-plugin-tsdoc/node_modules/eslint-visitor-keys": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+			"integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/eslint-plugin-tsdoc/node_modules/typescript": {
+			"version": "5.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
+			}
+		},
 		"node_modules/eslint-scope": {
 			"version": "8.4.0",
 			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
@@ -3421,6 +3647,13 @@
 			"funding": {
 				"url": "https://github.com/chalk/supports-color?sponsor=1"
 			}
+		},
+		"node_modules/jju": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
+			"integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
 			"version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -176,6 +176,7 @@
 		"eslint": "^9.39.5",
 		"eslint-config-prettier": "^10.1.8",
 		"eslint-plugin-prettier": "^5.5.6",
+		"eslint-plugin-tsdoc": "^0.5.2",
 		"husky": "^9.1.7",
 		"mocha": "^11.7.6",
 		"prettier": "^3.9.5",

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,5 +1,6 @@
 /**
- * @fileoverview Command handlers for VS Code extension commands.
+ * @packageDocumentation
+ * Command handlers for VS Code extension commands.
  *
  * This module exports the main command handlers that are registered
  * with VS Code to handle user-initiated minification operations.
@@ -8,8 +9,6 @@
  * - minifyCommand: In-place minification
  * - minifyInNewFileCommand: Create new minified files
  * - onSaveMinify: Auto-minification on file save
- *
- * @module commands
  */
 
 export * from './minifyCommand';

--- a/src/commands/minifyCommand.ts
+++ b/src/commands/minifyCommand.ts
@@ -1,5 +1,6 @@
 /**
- * @fileoverview Command handlers for CSS and JavaScript minification operations.
+ * @packageDocumentation
+ * Command handlers for CSS and JavaScript minification operations.
  *
  * This module contains the main command handlers that are registered with VS Code
  * to handle user-initiated minification requests. It supports both in-place
@@ -21,15 +22,13 @@ const processingDocuments = new Set<string>();
 
 /**
  * Configuration options for minification operations.
- *
- * @interface MinifyOptions
- * @property {boolean} [saveAsNewFile] - Whether to save the result as a new file instead of replacing content
- * @property {string} [filePrefix] - The prefix to use when creating new files (e.g., '.min', '-compressed')
- * @property {string} [debugSource] - Debug identifier for the source of the command
  */
 export interface MinifyOptions {
+	/** Whether to save the result as a new file instead of replacing content */
 	saveAsNewFile?: boolean;
+	/** The prefix to use when creating new files (e.g., '.min', '-compressed') */
 	filePrefix?: string;
+	/** Debug identifier for the source of the command */
 	debugSource?: string;
 }
 
@@ -41,14 +40,12 @@ export interface MinifyOptions {
  * 2. Calls the minification service
  * 3. Saves the result (either in-place or as new file)
  *
- * @async
- * @function processDocument
- * @param {vscode.TextDocument} document - The VS Code document to process
- * @param {MinifyOptions} [options={}] - Configuration options for the minification
- * @param {boolean} [skipSave=false] - Whether to skip saving the document (caller will handle save)
- * @returns {Promise<void>} Resolves when the minification process is complete
+ * @param document - The VS Code document to process
+ * @param options - Configuration options for the minification
+ * @param skipSave - Whether to skip saving the document (caller will handle save)
+ * @returns Resolves when the minification process is complete
  *
- * @throws {Error} When file validation fails or minification service encounters errors
+ * @throws When file validation fails or minification service encounters errors
  *
  * @example
  * ```typescript
@@ -109,12 +106,11 @@ async function processDocument(
  * as the first argument. When invoked from the editor context menu, keyboard
  * shortcut, or command palette, no URI is provided and the active editor is used.
  *
- * @async
- * @param {unknown} [uri] - Optional argument passed by VS Code. When invoked from the
+ * @param uri - Optional argument passed by VS Code. When invoked from the
  *   file explorer with a single file selected, this is a `vscode.Uri`. For multi-select
  *   or other invocation contexts, it may be an array or other type — in those cases
  *   the function falls back to the active editor.
- * @returns {Promise<vscode.TextDocument | undefined>} The resolved document, or undefined if
+ * @returns The resolved document, or undefined if
  *   none is available (e.g., no active editor and no URI provided).
  *   Returns undefined after showing an error message if the URI document cannot be opened.
  */
@@ -145,16 +141,14 @@ async function resolveTargetDocument(uri?: unknown): Promise<vscode.TextDocument
  * When processDocument saves the file, it would trigger onSaveMinify, but we prevent
  * that by adding the document to processingDocuments Set.
  *
- * @async
- * @function minifyCommand
- * @param {unknown} [uri] - Optional argument passed by VS Code. A `vscode.Uri` when
- *   invoked from the file explorer; undefined or other types for other contexts.
- * @returns {Promise<void>} Resolves when the command execution is complete
- *
- * @sideEffects
+ * @remarks
  * - Modifies the content of the target file(s)
  * - Shows user notifications for success/error states
  * - Saves modified documents to disk
+ *
+ * @param uri - Optional argument passed by VS Code. A `vscode.Uri` when
+ *   invoked from the file explorer; undefined or other types for other contexts.
+ * @returns Resolves when the command execution is complete
  *
  * @example
  * // This function is typically called by VS Code when the user:
@@ -195,16 +189,14 @@ export async function minifyCommand(uri?: unknown): Promise<void> {
  * The original file remains unchanged, and a new file is created with the
  * user-configured prefix (e.g., 'style.css' becomes 'style.min.css').
  *
- * @async
- * @function minifyInNewFileCommand
- * @param {unknown} [uri] - Optional argument passed by VS Code. A `vscode.Uri` when
- *   invoked from the file explorer; undefined or other types for other contexts.
- * @returns {Promise<void>} Resolves when the command execution is complete
- *
- * @sideEffects
+ * @remarks
  * - Creates a new file with minified content
  * - Opens the new file in VS Code editor
  * - Shows user notifications for success/error states
+ *
+ * @param uri - Optional argument passed by VS Code. A `vscode.Uri` when
+ *   invoked from the file explorer; undefined or other types for other contexts.
+ * @returns Resolves when the command execution is complete
  *
  * @example
  * // This function is typically called by VS Code when the user:
@@ -255,15 +247,13 @@ export async function minifyInNewFileCommand(uri?: unknown): Promise<void> {
  * - When creating new files: delegates to processDocument (single call)
  * - When in-place: calls getMinifiedText once, then uses setSkipAutoMinify to prevent recursion
  *
- * @async
- * @function onSaveMinify
- * @param {vscode.TextDocument} document - The document that was saved
- * @returns {Promise<void>} Resolves when auto-minification is complete
- *
- * @sideEffects
+ * @remarks
  * - Modifies the content of the saved file if it's CSS or JavaScript
  * - Shows user notifications for success/error states
  * - Saves the document again after minification (in-place mode only)
+ *
+ * @param document - The document that was saved
+ * @returns Resolves when auto-minification is complete
  *
  * @example
  * // This function is automatically called when:

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,6 @@
 /**
- * @fileoverview Main entry point for the CSS & JS Minifier VS Code extension.
+ * @packageDocumentation
+ * Main entry point for the CSS & JS Minifier VS Code extension.
  *
  * This extension provides commands to minify CSS and JavaScript files.
  * CSS minification uses the local LightningCSS library (Rust-based),
@@ -37,9 +38,7 @@ let outputChannel: vscode.OutputChannel;
  * Optional features (based on configuration):
  * - Auto-minification on file save (when `minifyOnSave` is enabled)
  *
- * @function activate
- * @param {vscode.ExtensionContext} context - The extension context provided by VS Code
- * @returns {void}
+ * @param context - The extension context provided by VS Code
  *
  * @example
  * // This function is automatically called by VS Code when:
@@ -100,9 +99,6 @@ export function activate(context: vscode.ExtensionContext): void {
  * This function is called by VS Code when the extension is being deactivated.
  * All registered commands and event listeners are automatically cleaned up
  * via the context.subscriptions array, so this function can remain empty.
- *
- * @function deactivate
- * @returns {void}
  *
  * @example
  * // This function is automatically called by VS Code when:

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,5 +1,6 @@
 /**
- * @fileoverview Application-wide constants.
+ * @packageDocumentation
+ * Application-wide constants.
  *
  * This module centralizes all constant values used throughout the extension.
  * Following Single Responsibility Principle, configuration values are
@@ -16,12 +17,10 @@
 
 /**
  * Number of bytes in a kilobyte.
- * @readonly
  */
 export const BYTES_PER_KB = 1024;
 
 /**
  * Number of bytes in a megabyte.
- * @readonly
  */
 export const BYTES_PER_MB = 1024 * 1024;

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -1,5 +1,6 @@
 /**
- * @fileoverview Utility helper functions.
+ * @packageDocumentation
+ * Utility helper functions.
  *
  * This module provides reusable helper functions used across the extension.
  * Following Single Responsibility Principle, each function handles one
@@ -16,9 +17,8 @@ import { BYTES_PER_KB } from './constants';
 /**
  * Formats bytes to human-readable string with KB or B units.
  *
- * @function formatBytes
- * @param {number} bytes - Size in bytes
- * @returns {string} Formatted string (e.g., "1.21 KB" or "512 B")
+ * @param bytes - Size in bytes
+ * @returns Formatted string (e.g., "1.21 KB" or "512 B")
  *
  * @example
  * formatBytes(1234) // Returns: "1.21 KB"
@@ -35,14 +35,15 @@ export function formatBytes(bytes: number): string {
 /**
  * Calculates minification statistics comparing original and minified text.
  *
- * @function calculateStats
- * @param {string} originalText - The original source code
- * @param {string} minifiedText - The minified code
- * @returns {MinificationStats} Statistics object with size and reduction data
+ * @param originalText - The original source code
+ * @param minifiedText - The minified code
+ * @returns Statistics object with size and reduction data
  *
  * @example
+ * ```typescript
  * const stats = calculateStats("body { color: red; }", "body{color:red}");
  * // Returns: { originalSize: 22, minifiedSize: 15, reductionPercent: 32, ... }
+ * ```
  */
 export function calculateStats(originalText: string, minifiedText: string): MinificationStats {
 	const textEncoder = new TextEncoder();

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,5 +1,6 @@
 /**
- * @fileoverview Library module exports.
+ * @packageDocumentation
+ * Library module exports.
  *
  * This module exports constants and helper functions used throughout
  * the extension. Following DDD principles, shared utilities are

--- a/src/services/fileService.ts
+++ b/src/services/fileService.ts
@@ -1,3 +1,15 @@
+/**
+ * @packageDocumentation
+ * File service module providing file system operations for the minification workflow.
+ *
+ * This module handles all file-related operations including saving minified content
+ * to new files, replacing document content in-place, and generating minified filenames.
+ *
+ * @author Miguel Colmenares
+ * @version 1.3.0
+ * @since 0.1.0
+ */
+
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { MinificationStats } from './minificationService';
@@ -10,19 +22,17 @@ import { t } from '@/utils/l10nHelper';
  * and automatically opens it in the VS Code editor. It provides user feedback
  * about the successful operation.
  *
- * @async
- * @function saveAsNewFile
- * @param {string} minifiedText - The minified content to save
- * @param {string} newFileName - The complete file path for the new file (including extension)
- * @param {MinificationStats} stats - Statistics about the minification process
- * @returns {Promise<void>} Resolves when the file is successfully created and opened
- *
- * @throws {Error} When file system operations fail (e.g., permissions, disk space)
- *
- * @sideEffects
+ * @remarks
  * - Creates a new file on the file system
  * - Opens the new file in VS Code editor
  * - Shows success notification to the user
+ *
+ * @param minifiedText - The minified content to save
+ * @param newFileName - The complete file path for the new file (including extension)
+ * @param stats - Statistics about the minification process
+ * @returns Resolves when the file is successfully created and opened
+ *
+ * @throws When file system operations fail (e.g., permissions, disk space)
  *
  * @example
  * ```typescript
@@ -84,22 +94,20 @@ export async function saveAsNewFile(
  * with the minified version. It uses VS Code's WorkspaceEdit API to ensure
  * the operation is atomic and can be undone by the user.
  *
- * @async
- * @function replaceDocumentContent
- * @param {vscode.TextDocument} document - The VS Code document to modify
- * @param {string} minifiedText - The minified content to replace the original with
- * @param {MinificationStats} stats - Statistics about the minification process
- * @param {boolean} [showNotification=true] - Whether to show success notification (default: true)
- * @param {boolean} [skipSave=false] - Whether to skip saving the document (default: false)
- * @returns {Promise<void>} Resolves when the document is updated and optionally saved
- *
- * @throws {Error} When the workspace edit fails or the document cannot be saved
- *
- * @sideEffects
+ * @remarks
  * - Modifies the content of the existing document
  * - Saves the document to disk (unless skipSave is true)
  * - Shows success notification to the user (unless suppressed)
  * - Adds an entry to VS Code's undo history
+ *
+ * @param document - The VS Code document to modify
+ * @param minifiedText - The minified content to replace the original with
+ * @param stats - Statistics about the minification process
+ * @param showNotification - Whether to show success notification (default: true)
+ * @param skipSave - Whether to skip saving the document (default: false)
+ * @returns Resolves when the document is updated and optionally saved
+ *
+ * @throws When the workspace edit fails or the document cannot be saved
  *
  * @example
  * ```typescript
@@ -173,10 +181,9 @@ export async function replaceDocumentContent(
  * inserting a user-configurable prefix (like '.min' or '-compressed') before
  * the file extension. It only works with supported file extensions (.css, .js).
  *
- * @function createMinifiedFileName
- * @param {string} originalFileName - The complete path to the original file
- * @param {string} prefix - The prefix to insert before the extension (e.g., '.min', '-compressed')
- * @returns {string} The new filename with the prefix inserted before the extension
+ * @param originalFileName - The complete path to the original file
+ * @param prefix - The prefix to insert before the extension (e.g., '.min', '-compressed')
+ * @returns The new filename with the prefix inserted before the extension
  *
  * @example
  * ```typescript
@@ -204,10 +211,8 @@ export function createMinifiedFileName(originalFileName: string, prefix: string)
  * Used when we need to save a document after modifications but want to avoid
  * triggering additional save events or showing duplicate notifications.
  *
- * @async
- * @function saveDocumentSilently
- * @param {vscode.TextDocument} document - The document to save
- * @returns {Promise<void>} Resolves when the document is saved
+ * @param document - The document to save
+ * @returns Resolves when the document is saved
  */
 export async function saveDocumentSilently(document: vscode.TextDocument): Promise<void> {
 	await document.save();

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,20 +1,20 @@
 /**
- * @fileoverview Service layer for minification and file operations.
+ * @packageDocumentation
+ * Service layer for minification and file operations.
  *
  * This module exports services that handle:
  * - Minification orchestration via the minificationService facade
- * - Minification strategies (local CSS, remote JS)
+ * - Minification strategies (local CSS, local JS)
  * - File system operations for saving and modifying files
  * - Filename generation utilities
  *
- * @module services
  * @since 0.1.0
  *
  * @example
  * ```typescript
  * import { getMinifiedText, MinificationResult } from './services';
  *
- * const result = await getMinifiedText(code, 'css');
+ * const result = getMinifiedText(code, 'css');
  * ```
  */
 

--- a/src/services/minificationService.ts
+++ b/src/services/minificationService.ts
@@ -1,5 +1,6 @@
 /**
- * @fileoverview Minification service facade that orchestrates all minification strategies.
+ * @packageDocumentation
+ * Minification service facade that orchestrates all minification strategies.
  *
  * This module serves as the main entry point for minification operations,
  * routing requests to the appropriate strategy based on file type:
@@ -39,7 +40,7 @@ export { MinificationResult, MinificationStats } from '@/types';
  * **CSS Minification (Local - LightningCSS):**
  * - No network required - works offline
  * - Rust-based parser (~60x faster than JavaScript alternatives)
- * - Full support for modern CSS features (@starting-style, CSS Nesting, etc.)
+ * - Full support for modern CSS features (\@starting-style, CSS Nesting, etc.)
  *
  * **JavaScript Minification (Local - oxc-minify):**
  * - No network required - works offline
@@ -47,13 +48,12 @@ export { MinificationResult, MinificationStats } from '@/types';
  * - Variable mangling, dead code elimination, constant folding
  * - No rate limits or file size restrictions
  *
- * @function getMinifiedText
- * @param {string} text - The source code to be minified (CSS or JavaScript)
- * @param {string} fileType - The file type identifier ('css' or 'javascript')
- * @returns {MinificationResult | null} The minified code with statistics, or null if minification failed
+ * @remarks
+ * Shows error messages to the user via VS Code notifications on failure.
  *
- * @sideEffects
- * - Shows error messages to the user via VS Code notifications on failure
+ * @param text - The source code to be minified (CSS or JavaScript)
+ * @param fileType - The file type identifier ('css' or 'javascript')
+ * @returns The minified code with statistics, or null if minification failed
  *
  * @example
  * ```typescript

--- a/src/services/strategies/index.ts
+++ b/src/services/strategies/index.ts
@@ -1,5 +1,6 @@
 /**
- * @fileoverview Minification strategies module exports.
+ * @packageDocumentation
+ * Minification strategies module exports.
  *
  * This module exports all available minification strategies:
  * - Local CSS minification using LightningCSS (Rust-based)

--- a/src/services/strategies/localCssMinifier.ts
+++ b/src/services/strategies/localCssMinifier.ts
@@ -1,5 +1,6 @@
 /**
- * @fileoverview Local CSS minification strategy using LightningCSS.
+ * @packageDocumentation
+ * Local CSS minification strategy using LightningCSS.
  *
  * This module provides offline CSS minification without requiring network access.
  * It uses LightningCSS (written in Rust) for extremely fast and modern CSS processing.
@@ -29,15 +30,14 @@ import { formatBytes } from '@/lib';
  * - Combining longhand properties into shorthands
  * - Removing duplicate rules
  * - Optimizing colors, fonts, and other values
- * - Full support for modern CSS features (@starting-style, CSS Nesting, etc.)
+ * - Full support for modern CSS features (\@starting-style, CSS Nesting, etc.)
  * - ~60x faster than JavaScript-based minifiers
  *
- * @function minifyCss
- * @param {string} text - The CSS source code to be minified
- * @returns {MinificationResult | null} The minified CSS with statistics, or null if minification failed
+ * @remarks
+ * Shows error messages to the user via VS Code notifications on failure.
  *
- * @sideEffects
- * - Shows error messages to the user via VS Code notifications on failure
+ * @param text - The CSS source code to be minified
+ * @returns The minified CSS with statistics, or null if minification failed
  *
  * @example
  * ```typescript

--- a/src/services/strategies/localJsMinifier.ts
+++ b/src/services/strategies/localJsMinifier.ts
@@ -1,5 +1,6 @@
 /**
- * @fileoverview Local JavaScript minification strategy using oxc-minify.
+ * @packageDocumentation
+ * Local JavaScript minification strategy using oxc-minify.
  *
  * This module provides offline JavaScript minification without requiring network access.
  * It uses oxc-minify (written in Rust) for fast and modern JavaScript processing,
@@ -44,12 +45,11 @@ const { minifySync } = oxcMinify;
  * - No network dependency - works fully offline
  * - No rate limits or file size restrictions
  *
- * @function minifyJs
- * @param {string} text - The JavaScript source code to be minified
- * @returns {MinificationResult | null} The minified JavaScript with statistics, or null if minification failed
+ * @remarks
+ * Shows error messages to the user via VS Code notifications on failure.
  *
- * @sideEffects
- * - Shows error messages to the user via VS Code notifications on failure
+ * @param text - The JavaScript source code to be minified
+ * @returns The minified JavaScript with statistics, or null if minification failed
  *
  * @example
  * ```typescript

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,6 @@
 /**
- * @fileoverview Type definitions module exports.
+ * @packageDocumentation
+ * Type definitions module exports.
  *
  * This module exports all type definitions used throughout the extension.
  * Following DDD principles, types are centralized here for consistent

--- a/src/types/minification.ts
+++ b/src/types/minification.ts
@@ -1,5 +1,6 @@
 /**
- * @fileoverview Minification-related type definitions.
+ * @packageDocumentation
+ * Minification-related type definitions.
  *
  * This module contains interfaces and types used across all minification
  * strategies and services.
@@ -11,30 +12,26 @@
 
 /**
  * Statistics about the minification process.
- *
- * @interface MinificationStats
- * @property {number} originalSize - Original file size in bytes
- * @property {number} minifiedSize - Minified file size in bytes
- * @property {number} reductionPercent - Percentage of size reduction (0-100)
- * @property {string} originalSizeKB - Formatted original size (e.g., "1.21 KB")
- * @property {string} minifiedSizeKB - Formatted minified size (e.g., "0.66 KB")
  */
 export interface MinificationStats {
+	/** Original file size in bytes */
 	originalSize: number;
+	/** Minified file size in bytes */
 	minifiedSize: number;
+	/** Percentage of size reduction (0-100) */
 	reductionPercent: number;
+	/** Formatted original size (e.g., "1.21 KB") */
 	originalSizeKB: string;
+	/** Formatted minified size (e.g., "0.66 KB") */
 	minifiedSizeKB: string;
 }
 
 /**
  * Result of minification with statistics.
- *
- * @interface MinificationResult
- * @property {string} minifiedText - The minified code
- * @property {MinificationStats} stats - Statistics about the minification
  */
 export interface MinificationResult {
+	/** The minified code */
 	minifiedText: string;
+	/** Statistics about the minification */
 	stats: MinificationStats;
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,10 +1,9 @@
 /**
- * @fileoverview Utility functions for file validation and type checking.
+ * @packageDocumentation
+ * Utility functions for file validation and type checking.
  *
  * This module exports validation functions used throughout the extension
  * to ensure files are appropriate for minification before processing.
- *
- * @module utils
  */
 
 export * from './validators';

--- a/src/utils/l10nHelper.ts
+++ b/src/utils/l10nHelper.ts
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Thin re-export of `vscode.l10n.t()` — the extension follows
+ * Thin re-export of `vscode.l10n.t()` — the extension follows
  * VS Code's canonical localization pattern where the English source string is
  * passed as the first argument to `t()` and non-English translations live in
  * `l10n/bundle.l10n.<locale>.json` (loaded automatically because `package.json`
@@ -32,8 +32,8 @@ import * as vscode from 'vscode';
  * the lookup key against the loaded locale bundle and as the fallback value
  * when no translation is available.
  *
- * @param message English source string. Also the key used in bundle files.
- * @param args    Optional positional values to interpolate into `{0}`, `{1}`, …
+ * @param message - English source string. Also the key used in bundle files.
+ * @param args - Optional positional values to interpolate into `{0}`, `{1}`, …
  * @returns The translated message when a bundle matches, otherwise `message`
  *          with placeholders substituted.
  */

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -3,8 +3,6 @@ import { t } from './l10nHelper';
 
 /**
  * Supported file types for minification.
- * @readonly
- * @enum {string}
  */
 const SUPPORTED_FILE_TYPES = {
 	CSS: 'css',
@@ -17,9 +15,8 @@ const SUPPORTED_FILE_TYPES = {
  * This function checks if the file type is either CSS or JavaScript,
  * which are the only file types supported for minification.
  *
- * @function isValidFileType
- * @param {string} fileType - The VS Code language identifier (e.g., 'css', 'javascript')
- * @returns {boolean} True if the file type is supported (css or javascript), false otherwise
+ * @param fileType - The VS Code language identifier (e.g., 'css', 'javascript')
+ * @returns True if the file type is supported (css or javascript), false otherwise
  *
  * @example
  * ```typescript
@@ -40,13 +37,12 @@ export function isValidFileType(fileType: string): boolean {
  * user-friendly error messages when the file type is not supported.
  * It's designed to be used in command handlers where user feedback is required.
  *
- * @function validateFileType
- * @param {string} fileType - The VS Code language identifier to validate
- * @returns {boolean} True if validation passes, false if validation fails
+ * @remarks
+ * Shows an error message to the user via VS Code's notification system
+ * when the file type is not supported.
  *
- * @sideEffects
- * - Shows an error message to the user via VS Code's notification system
- *   when the file type is not supported
+ * @param fileType - The VS Code language identifier to validate
+ * @returns True if validation passes, false if validation fails
  *
  * @example
  * ```typescript
@@ -74,13 +70,12 @@ export function validateFileType(fileType: string): boolean {
  * This function ensures that there is actual content to minify before processing.
  * Empty files should be handled gracefully with appropriate user feedback.
  *
- * @function validateContentLength
- * @param {string} text - The complete text content of the file to validate
- * @param {string} fileType - The file type identifier (used for contextual error messages)
- * @returns {boolean} True if the file has content (length > 0), false if empty
+ * @remarks
+ * Shows an informative error message to the user when the file is empty.
  *
- * @sideEffects
- * - Shows an informative error message to the user when the file is empty
+ * @param text - The complete text content of the file to validate
+ * @param fileType - The file type identifier (used for contextual error messages)
+ * @returns True if the file has content (length \> 0), false if empty
  *
  * @example
  * ```typescript

--- a/tsdoc.json
+++ b/tsdoc.json
@@ -1,0 +1,20 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"tagDefinitions": [
+		{
+			"tagName": "@since",
+			"syntaxKind": "modifier",
+			"allowMultiple": false
+		},
+		{
+			"tagName": "@version",
+			"syntaxKind": "modifier",
+			"allowMultiple": false
+		},
+		{
+			"tagName": "@author",
+			"syntaxKind": "modifier",
+			"allowMultiple": false
+		}
+	]
+}


### PR DESCRIPTION
## Purpose

Migrates all TypeScript documentation comments from JSDoc to the [TSDoc](https://tsdoc.org/) standard, providing better tooling support and TypeScript-native documentation.

## Key Changes

- **Tooling**: Added `eslint-plugin-tsdoc` with `'tsdoc/syntax': 'error'` rule (enforced in `src/**`, disabled in tests)
- **Configuration**: Created `tsdoc.json` with custom modifier tags (`@since`, `@version`, `@author`)
- **17 source files migrated**: All files under `src/` (types, lib, utils, services, commands, extension.ts)
- **Documentation**: Updated `copilot-instructions.md` to reference TSDoc

## Migration Rules Applied

| JSDoc Pattern | TSDoc Replacement |
|---|---|
| `@fileoverview` | `@packageDocumentation` (entry points) or removed |
| `@function`, `@async`, `@interface` | Removed (TypeScript infers) |
| `@param {type} name - desc` | `@param name - desc` |
| `@returns {type} desc` | `@returns desc` |
| `@property {type} name` | Inline `/** */` on members |
| `@module` | Removed |
| `@sideEffects` | Moved to `@remarks` |

## Validation

- ✅ ESLint passes with 0 TSDoc errors (from 195 baseline)
- ✅ TypeScript compilation succeeds
- ✅ Webpack production build succeeds
- ⚠️ VS Code test runner could not execute in worktree (path too long for Unix sockets) — CI matrix will validate

## Testing

Documentation-only changes — no functional code modified. All 52 tests expected to pass in CI.

Resolves #182