### PR TITLE
chore: Update minor and patch dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,17 +9,17 @@
 			"version": "1.3.3",
 			"license": "MIT",
 			"dependencies": {
-				"detect-libc": "^2.0.4",
+				"detect-libc": "^2.1.2",
 				"lightningcss": "^1.33.0",
-				"oxc-minify": "^0.140.0"
+				"oxc-minify": "^0.141.0"
 			},
 			"devDependencies": {
-				"@types/mocha": "^10.0.6",
+				"@types/mocha": "^10.0.10",
 				"@types/node": "^26.1.1",
 				"@types/sinon": "^22.0.0",
 				"@types/vscode": "^1.125.0",
-				"@typescript-eslint/eslint-plugin": "^8.64.0",
-				"@typescript-eslint/parser": "^8.58.0",
+				"@typescript-eslint/eslint-plugin": "^8.65.0",
+				"@typescript-eslint/parser": "^8.65.0",
 				"@vscode/l10n-dev": "^0.0.35",
 				"@vscode/test-cli": "^0.0.15",
 				"@vscode/test-electron": "^3.0.0",
@@ -29,8 +29,8 @@
 				"eslint-plugin-tsdoc": "^0.5.2",
 				"husky": "^9.1.7",
 				"mocha": "^11.7.6",
-				"prettier": "^3.9.5",
-				"sinon": "^22.0.0",
+				"prettier": "^3.9.6",
+				"sinon": "^22.1.0",
 				"ts-loader": "^9.6.2",
 				"typescript": "^6.0.3",
 				"webpack": "^5.108.4",
@@ -625,9 +625,9 @@
 			}
 		},
 		"node_modules/@oxc-minify/binding-android-arm-eabi": {
-			"version": "0.140.0",
-			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-android-arm-eabi/-/binding-android-arm-eabi-0.140.0.tgz",
-			"integrity": "sha512-z+SVtvvaC+qv1oRC0n7LJ6SIuU8xzCWM+MdQIGyUyeb7W0K3QibUg1J5hPFm+a/49mVS6v5CUpJP/07HEZwTjQ==",
+			"version": "0.141.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-android-arm-eabi/-/binding-android-arm-eabi-0.141.0.tgz",
+			"integrity": "sha512-tt3ekadMhd/Q+9/mU1RaZWCUAJhOQgHsUD9tn0btFhEkZyeTg1rKt2+wzv+wjBE3QXlxVdV6sYMLKnbt8XdR+g==",
 			"cpu": [
 				"arm"
 			],
@@ -641,9 +641,9 @@
 			}
 		},
 		"node_modules/@oxc-minify/binding-android-arm64": {
-			"version": "0.140.0",
-			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-android-arm64/-/binding-android-arm64-0.140.0.tgz",
-			"integrity": "sha512-CUX3s3hz1ZCTv6/UwS6pnQ79XSyRhU2rn0GWKK30BhvvzDv43KSSlXrocgeETzfLYXL+/xnsh08Nw1fq1fxbcQ==",
+			"version": "0.141.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-android-arm64/-/binding-android-arm64-0.141.0.tgz",
+			"integrity": "sha512-i7OGI2bFipaSlgwap/qiXcCmPbZMhlYdKAQvUtNziX8CJamNzhlqMNw4jz7wYdVNfcKuQ1eoyi7XMYCbNnKRtg==",
 			"cpu": [
 				"arm64"
 			],
@@ -657,9 +657,9 @@
 			}
 		},
 		"node_modules/@oxc-minify/binding-darwin-arm64": {
-			"version": "0.140.0",
-			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-darwin-arm64/-/binding-darwin-arm64-0.140.0.tgz",
-			"integrity": "sha512-R9QvHsauZGCCn6gN38XD/9361re4K4Hf9H8ajWAN4sVJB3w/rjtmF+aRD5HJF7EoK1OkocW4ENJtV3yVHMnWmw==",
+			"version": "0.141.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-darwin-arm64/-/binding-darwin-arm64-0.141.0.tgz",
+			"integrity": "sha512-YOp5tcQRkLUbvII+EVwDss+Ww16b/V8XfrqNRDOTaLb/azGTb87iyS5drXfRosONv7Jp8/t8qRFC9K0aj1yYZA==",
 			"cpu": [
 				"arm64"
 			],
@@ -673,9 +673,9 @@
 			}
 		},
 		"node_modules/@oxc-minify/binding-darwin-x64": {
-			"version": "0.140.0",
-			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-darwin-x64/-/binding-darwin-x64-0.140.0.tgz",
-			"integrity": "sha512-ux6QN45jlB52GgQ745ZFvSSrSyyEaFTg9xZscVimcQxUFLPB/j8h8BzYeFaxgHqSVdBbJk/pbOaB6P5Mw5lz6w==",
+			"version": "0.141.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-darwin-x64/-/binding-darwin-x64-0.141.0.tgz",
+			"integrity": "sha512-9Z25dRX02krxcFXTIoZ3ym0+CF3gZ6RiU+bbckFT4l+d5LcQePfM1tR12zEW+GDTl0atCNG2TuEu61tT4L2LIQ==",
 			"cpu": [
 				"x64"
 			],
@@ -689,9 +689,9 @@
 			}
 		},
 		"node_modules/@oxc-minify/binding-freebsd-x64": {
-			"version": "0.140.0",
-			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-freebsd-x64/-/binding-freebsd-x64-0.140.0.tgz",
-			"integrity": "sha512-CveDbUDqrdJSBITHXt/61uhnrthJO8ayje22MrG31WVbbm9Y5XShGZTG7zj/zzG2w/DAprPEkOct97csL8kyXw==",
+			"version": "0.141.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-freebsd-x64/-/binding-freebsd-x64-0.141.0.tgz",
+			"integrity": "sha512-QtFX48viQb3Di8GkxhH9SPYZaafIwyEa51iFBALXz2x1WdYvZeAxgl33GjETq5/YXS7MiPYrZ7FNs3UHtPsTdg==",
 			"cpu": [
 				"x64"
 			],
@@ -705,9 +705,9 @@
 			}
 		},
 		"node_modules/@oxc-minify/binding-linux-arm-gnueabihf": {
-			"version": "0.140.0",
-			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.140.0.tgz",
-			"integrity": "sha512-Vt+n93L++7rVkH4btk6jXdGbZdRYR7QJcLeRj5aDu++Q9DYKho+a5Lu6PoImKIyrghFVAn7Czzz5oBmYM5aAgg==",
+			"version": "0.141.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.141.0.tgz",
+			"integrity": "sha512-HcgqdmJY+0qWnolOTxrvzilDTvs3q7RF2XcvO0q0iDld8SZBNARVqrWY9k5WwCMTZSJKCWfL/QqpUMBnyIHQAA==",
 			"cpu": [
 				"arm"
 			],
@@ -721,9 +721,9 @@
 			}
 		},
 		"node_modules/@oxc-minify/binding-linux-arm-musleabihf": {
-			"version": "0.140.0",
-			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.140.0.tgz",
-			"integrity": "sha512-EvD7JEgVDzqiFPvS0rr9jUIEmFR9QsxR18BpbVzLs8Xo4GHqCoA0FrXMNziYWBSLqgBlt+LGs9yk0SjMx12RsA==",
+			"version": "0.141.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.141.0.tgz",
+			"integrity": "sha512-u8c4OPT8A6lx+mnFkMczIHCQQNqbqdEGwep2PlOoCgQhwsWR3auvs4cyD1JJW6huZQjeq0gJJ0dJtvJq3yLy+w==",
 			"cpu": [
 				"arm"
 			],
@@ -737,9 +737,9 @@
 			}
 		},
 		"node_modules/@oxc-minify/binding-linux-arm64-gnu": {
-			"version": "0.140.0",
-			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.140.0.tgz",
-			"integrity": "sha512-Yb8WSpVyEa8UjwkZIyBBZCRKKOr1Hkf44YbT8gHWhJy0AjLHrXGgzJd7hnFXYLkMIllloux3yTNsVo/Q4loy3A==",
+			"version": "0.141.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.141.0.tgz",
+			"integrity": "sha512-n+ljU1cOCpIqVDxYiYmNimXGKNYlPIkdWVrkC4hOQF3B7YqkSRtEWbHcvedinBqNCwUF+azynDWor5Bq3/BdDw==",
 			"cpu": [
 				"arm64"
 			],
@@ -753,9 +753,9 @@
 			}
 		},
 		"node_modules/@oxc-minify/binding-linux-arm64-musl": {
-			"version": "0.140.0",
-			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.140.0.tgz",
-			"integrity": "sha512-1eudG61G/pMZsTB4t86oDjyq8GDa9QoNLSyPMQQPVwcVWqUpI9WOKak5SruZ4XDnGSN0SsRiH0TtKM0sHA0d4A==",
+			"version": "0.141.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.141.0.tgz",
+			"integrity": "sha512-Xkb5QCOywz/YbL+8LVQSzOxuz2jhRweBjr4BnQO7CQXAtQLLCNoll7v2qLg9OCzdqdhFw9uNgZ6aTBVADBhiPg==",
 			"cpu": [
 				"arm64"
 			],
@@ -769,9 +769,9 @@
 			}
 		},
 		"node_modules/@oxc-minify/binding-linux-ppc64-gnu": {
-			"version": "0.140.0",
-			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.140.0.tgz",
-			"integrity": "sha512-oISQKJoTYWq1iB8LzkKc09j6E104g1QQAUr+yb1T0is41RFdV11jc5kzT0Iwg167BsPqokmzjNnylBQT7Z16ww==",
+			"version": "0.141.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.141.0.tgz",
+			"integrity": "sha512-IbVb+m0iL053WitFNnQbtmd8OjYGr4Xn5NTuAiYz8tJBtn82okEZFi0OgaeaHQE4aPZGOKPcSVlt1OMPtMoPCw==",
 			"cpu": [
 				"ppc64"
 			],
@@ -785,9 +785,9 @@
 			}
 		},
 		"node_modules/@oxc-minify/binding-linux-riscv64-gnu": {
-			"version": "0.140.0",
-			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.140.0.tgz",
-			"integrity": "sha512-S33Teg0B3SroYNlD7sFlZ25e9pjj1k7AkFjNOAOjBFBoX0MBP3idhx7k4jCkcK1kWvbRUmT7qUErsoZxtBfF4Q==",
+			"version": "0.141.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.141.0.tgz",
+			"integrity": "sha512-Sc/GAiyelxg8oXlBgmJI6OuKKHmg4rF0RvTLC8eL5V3qKDXrMdVWiJziwVBqN5oiFEog35ZM1/YNF63IZOdZjw==",
 			"cpu": [
 				"riscv64"
 			],
@@ -801,9 +801,9 @@
 			}
 		},
 		"node_modules/@oxc-minify/binding-linux-riscv64-musl": {
-			"version": "0.140.0",
-			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.140.0.tgz",
-			"integrity": "sha512-vjMzSh6Yo6stgvSIfWiBAlmu+QbeX7AF16iL5Bhm7xeLIOSbZ7kTAWWADyVRCpUTM2LYRdogWnq9eIp7MOyDrA==",
+			"version": "0.141.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.141.0.tgz",
+			"integrity": "sha512-KHYS3oQJ5r1QBVAVubUy6UPRWYghqkjCOfNlGeH/sWlmfeM2OD74+Stc8eHmVm7QI2wDooOIlZfUso0Yz0jyRg==",
 			"cpu": [
 				"riscv64"
 			],
@@ -817,9 +817,9 @@
 			}
 		},
 		"node_modules/@oxc-minify/binding-linux-s390x-gnu": {
-			"version": "0.140.0",
-			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.140.0.tgz",
-			"integrity": "sha512-FYo0tG/BoZvs2LpMofMEKf0qHQHJklS3SbD8Xwicj2NgEfW6Y04ucU1MmL8shL5TjHmRcs7myXz3eHr9rGc6dw==",
+			"version": "0.141.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.141.0.tgz",
+			"integrity": "sha512-WyacIrs13ewOnGngxNmPF00xn0+aOYHTMSSMljNN3VShSbqB0A7ZEikR7q9fmmnBTf/jloQUO6bjzK85BFfl0w==",
 			"cpu": [
 				"s390x"
 			],
@@ -833,9 +833,9 @@
 			}
 		},
 		"node_modules/@oxc-minify/binding-linux-x64-gnu": {
-			"version": "0.140.0",
-			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.140.0.tgz",
-			"integrity": "sha512-2dThpMwGQohXph9yzAQNVsSwMarzAD8LkDyKhCbkoRJ/O2knpQNM3d6mMjqNJquFJxuniHNHQsCvV2N1R9/VoQ==",
+			"version": "0.141.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.141.0.tgz",
+			"integrity": "sha512-mP69bh2L/VVq10UEQ3wb0EsO0472TzOIZUfS/ADmxnr4gSxAzhRbO8w5QryL3BNyyyjSaXIlrAnAKO6G3srGwg==",
 			"cpu": [
 				"x64"
 			],
@@ -849,9 +849,9 @@
 			}
 		},
 		"node_modules/@oxc-minify/binding-linux-x64-musl": {
-			"version": "0.140.0",
-			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-x64-musl/-/binding-linux-x64-musl-0.140.0.tgz",
-			"integrity": "sha512-47zuiYiy9fKIPBDBr+XxZwaJcd+ZtDI0ogNpJJunJphpWzBg3iyTyVoDU4TXRddSMkYoTSJJ3pejXOhvf+/Xhg==",
+			"version": "0.141.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-x64-musl/-/binding-linux-x64-musl-0.141.0.tgz",
+			"integrity": "sha512-B4w1uz+GPVD5iRNn9StLSG0ug5DNAy5YQVswjPy5fXNNO6JyADvmu4KZyE6tWCA6Kbz/84icD6RJ1TKVis2HSg==",
 			"cpu": [
 				"x64"
 			],
@@ -865,9 +865,9 @@
 			}
 		},
 		"node_modules/@oxc-minify/binding-openharmony-arm64": {
-			"version": "0.140.0",
-			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-openharmony-arm64/-/binding-openharmony-arm64-0.140.0.tgz",
-			"integrity": "sha512-q97mzDdkbTUnRbcZtkYt8dwx7hMW0zwIqpaq+hN5cZ5N9VPvmpQ5/hITE2n4zskJ4pAYOWfQepuuagcTo0yCDQ==",
+			"version": "0.141.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-openharmony-arm64/-/binding-openharmony-arm64-0.141.0.tgz",
+			"integrity": "sha512-p3nU1bo2t+QRvvqOPUqI8aEk8puhYdMq5cnjulovfKykWRi8cMcJJvuLp+RPkf45lUcTQdNG/YMFqR5eYGZfwA==",
 			"cpu": [
 				"arm64"
 			],
@@ -881,9 +881,9 @@
 			}
 		},
 		"node_modules/@oxc-minify/binding-wasm32-wasi": {
-			"version": "0.140.0",
-			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-wasm32-wasi/-/binding-wasm32-wasi-0.140.0.tgz",
-			"integrity": "sha512-J5SiqVtBbfujhWql3HZnL2E4nVoqgmoqgkbX9W3ZOLRS9/PMK/pFqVU0A4F86PIjFq2zPsrUliI/+b5NHfx6tQ==",
+			"version": "0.141.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-wasm32-wasi/-/binding-wasm32-wasi-0.141.0.tgz",
+			"integrity": "sha512-Qb72fqFRs2Xu+KvAwisc1Fxn/rd/KROnFIdkFv77dTVmrKsq2HOCjWvxlPzjHcxNIgGUUJtpmNolrs7GYcopKg==",
 			"cpu": [
 				"wasm32"
 			],
@@ -899,9 +899,9 @@
 			}
 		},
 		"node_modules/@oxc-minify/binding-win32-arm64-msvc": {
-			"version": "0.140.0",
-			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.140.0.tgz",
-			"integrity": "sha512-v49UNq31wguYKsNZrcR6IJSLTQ0iIkRA3ybOPUCEWXKUcOSAce9juGet0U9kV4MFu24ecN3Dvpl1U6SDBy65wQ==",
+			"version": "0.141.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.141.0.tgz",
+			"integrity": "sha512-C+lcoyJycCgq4MIgGe2K/xYZHKjaSfRMa+Bm88UoPK7U/mFHYoAnICbftkLh3IVnIuQAr9vGItp0w/m39VajgQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -915,9 +915,9 @@
 			}
 		},
 		"node_modules/@oxc-minify/binding-win32-ia32-msvc": {
-			"version": "0.140.0",
-			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.140.0.tgz",
-			"integrity": "sha512-+ZCR0ktjrfy1CoJjSDOhNftWBPqvePmEbqtInlhVXPH0yLQM0q3k0yROZ834vXU3py43gVaUElHTc0lTdb5D9A==",
+			"version": "0.141.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.141.0.tgz",
+			"integrity": "sha512-MAtLZpArekuD94sTmQYz7YAn3xDrq4wqT/71CUrv8ij2TSbYZGqDtA44ujP3977180ITcffPQYfHKXYX7arsgg==",
 			"cpu": [
 				"ia32"
 			],
@@ -931,9 +931,9 @@
 			}
 		},
 		"node_modules/@oxc-minify/binding-win32-x64-msvc": {
-			"version": "0.140.0",
-			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.140.0.tgz",
-			"integrity": "sha512-A+disxuZHYCe1ttJnD+ljiGKDNJfeu9EZKuGIL3aU5pbNVDuwMWShpiyX3+OSQDYrbXF1xtNqrKadgw87Q5Neg==",
+			"version": "0.141.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.141.0.tgz",
+			"integrity": "sha512-9B0SzKsstTUETz2SblLd2gZJ2H36GyBmZmwcZVwEaFOYW+luVm78yCSjZwja/xyl+PV6JsLhxQv+rgH46rpxQw==",
 			"cpu": [
 				"x64"
 			],
@@ -1084,17 +1084,17 @@
 			"license": "MIT"
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "8.64.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.64.0.tgz",
-			"integrity": "sha512-CGvQPBxN3wZLu6Rz2kFUpZeoCm78xUic92ck39KPePkO1NPOwjCqdQnm5Q87tpWw9vcBvW8XLrDXjH9PWYtJ3Q==",
+			"version": "8.65.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
+			"integrity": "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.12.2",
-				"@typescript-eslint/scope-manager": "8.64.0",
-				"@typescript-eslint/type-utils": "8.64.0",
-				"@typescript-eslint/utils": "8.64.0",
-				"@typescript-eslint/visitor-keys": "8.64.0",
+				"@typescript-eslint/scope-manager": "8.65.0",
+				"@typescript-eslint/type-utils": "8.65.0",
+				"@typescript-eslint/utils": "8.65.0",
+				"@typescript-eslint/visitor-keys": "8.65.0",
 				"ignore": "^7.0.5",
 				"natural-compare": "^1.4.0",
 				"ts-api-utils": "^2.5.0"
@@ -1107,22 +1107,22 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/parser": "^8.64.0",
+				"@typescript-eslint/parser": "^8.65.0",
 				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
 				"typescript": ">=4.8.4 <6.1.0"
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "8.64.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.64.0.tgz",
-			"integrity": "sha512-KA0OshtlcCCXmbfqyZkM5pV3/WNraJf7DkJRLpyrmwPtud57H5BDX7C3k0LPSPxpprfRL+cJDGabF10mvNCoCw==",
+			"version": "8.65.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.65.0.tgz",
+			"integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "8.64.0",
-				"@typescript-eslint/types": "8.64.0",
-				"@typescript-eslint/typescript-estree": "8.64.0",
-				"@typescript-eslint/visitor-keys": "8.64.0",
+				"@typescript-eslint/scope-manager": "8.65.0",
+				"@typescript-eslint/types": "8.65.0",
+				"@typescript-eslint/typescript-estree": "8.65.0",
+				"@typescript-eslint/visitor-keys": "8.65.0",
 				"debug": "^4.4.3"
 			},
 			"engines": {
@@ -1138,14 +1138,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/project-service": {
-			"version": "8.64.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.64.0.tgz",
-			"integrity": "sha512-tk4WpOJ6IEbGrVHaNmM0YRrwAD3exZlIK3iadQNAxh4YKk6jvUQ4ecq18n+v7+meh+cJ3j+D8nbk8sRKhlwLQg==",
+			"version": "8.65.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
+			"integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/tsconfig-utils": "^8.64.0",
-				"@typescript-eslint/types": "^8.64.0",
+				"@typescript-eslint/tsconfig-utils": "^8.65.0",
+				"@typescript-eslint/types": "^8.65.0",
 				"debug": "^4.4.3"
 			},
 			"engines": {
@@ -1160,14 +1160,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.64.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.64.0.tgz",
-			"integrity": "sha512-CXEaFdYXjSTgKhisNkwCcJwTP8Pl+fmRrEQrri4nm3vU743bALrxzLmq7fHG/7e6a5xO0lDYeURpZmBuhHk54w==",
+			"version": "8.65.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
+			"integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.64.0",
-				"@typescript-eslint/visitor-keys": "8.64.0"
+				"@typescript-eslint/types": "8.65.0",
+				"@typescript-eslint/visitor-keys": "8.65.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1178,9 +1178,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/tsconfig-utils": {
-			"version": "8.64.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.64.0.tgz",
-			"integrity": "sha512-2yo8rRNKuzbVWQp5kslhANqZ2uDAeROQHBRZNPu8JDsHmeFNj/XJJhX/FhNUWmkHHvoNsKa6+tHJiig87EzsQw==",
+			"version": "8.65.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
+			"integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -1195,15 +1195,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "8.64.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.64.0.tgz",
-			"integrity": "sha512-XWG4Fmmv/6SvyS9nH8jWrKs6terwJvE8cyRt1CzYYqzp9OrPhCT4cMc/f7C6RZCwG+qMmiffJS1/qJP8G1URtg==",
+			"version": "8.65.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
+			"integrity": "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.64.0",
-				"@typescript-eslint/typescript-estree": "8.64.0",
-				"@typescript-eslint/utils": "8.64.0",
+				"@typescript-eslint/types": "8.65.0",
+				"@typescript-eslint/typescript-estree": "8.65.0",
+				"@typescript-eslint/utils": "8.65.0",
 				"debug": "^4.4.3",
 				"ts-api-utils": "^2.5.0"
 			},
@@ -1220,9 +1220,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "8.64.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.64.0.tgz",
-			"integrity": "sha512-qjhfuTfLXjA4IOzXvz0rTjT01BqEiIgPoUeMwiEjnaHKJMTNo8rH5pYW1a2L/0Dnux2fPC85AeyJoWaGa8WxTA==",
+			"version": "8.65.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
+			"integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -1234,16 +1234,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "8.64.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.64.0.tgz",
-			"integrity": "sha512-Pztpsn1aCE1oWDvDEfUk31nngvvF7vUB5SwHFEaZIFpvw7WJtqUHHL4plBZDA9HfWJJjL13BdG0YrJInTUvoVA==",
+			"version": "8.65.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
+			"integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/project-service": "8.64.0",
-				"@typescript-eslint/tsconfig-utils": "8.64.0",
-				"@typescript-eslint/types": "8.64.0",
-				"@typescript-eslint/visitor-keys": "8.64.0",
+				"@typescript-eslint/project-service": "8.65.0",
+				"@typescript-eslint/tsconfig-utils": "8.65.0",
+				"@typescript-eslint/types": "8.65.0",
+				"@typescript-eslint/visitor-keys": "8.65.0",
 				"debug": "^4.4.3",
 				"minimatch": "^10.2.2",
 				"semver": "^7.7.3",
@@ -1262,16 +1262,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "8.64.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.64.0.tgz",
-			"integrity": "sha512-aJUGVB3+U0htrrCjoA8qukw8cm8fNCGAxK/tVoS70k8aeb7DETKeFozRiVFIwEeN9WJLsjaP3ph8I60tY2XZoQ==",
+			"version": "8.65.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
+			"integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.9.1",
-				"@typescript-eslint/scope-manager": "8.64.0",
-				"@typescript-eslint/types": "8.64.0",
-				"@typescript-eslint/typescript-estree": "8.64.0"
+				"@typescript-eslint/scope-manager": "8.65.0",
+				"@typescript-eslint/types": "8.65.0",
+				"@typescript-eslint/typescript-estree": "8.65.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1286,13 +1286,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.64.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.64.0.tgz",
-			"integrity": "sha512-mrtuL8Nsn6gi2H4mo5KMTp823M+3Q19Ew/i+Zlikq20tIMm99C3Ez0dCmkWWnxut20esQvTg8aUSEhMcAOXhEw==",
+			"version": "8.65.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
+			"integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.64.0",
+				"@typescript-eslint/types": "8.65.0",
 				"eslint-visitor-keys": "^5.0.0"
 			},
 			"engines": {
@@ -4575,9 +4575,9 @@
 			}
 		},
 		"node_modules/oxc-minify": {
-			"version": "0.140.0",
-			"resolved": "https://registry.npmjs.org/oxc-minify/-/oxc-minify-0.140.0.tgz",
-			"integrity": "sha512-WWZgfS0FoojXPCAQLimENEv9EJ4AmSnY+wU8PepebcYg+4SY8cjrB3nDUuQwWSVfLIcZ6F++ZecFudJZdLR71Q==",
+			"version": "0.141.0",
+			"resolved": "https://registry.npmjs.org/oxc-minify/-/oxc-minify-0.141.0.tgz",
+			"integrity": "sha512-+T/r+nBaKTT7UL5WDZHH8+l0bz+IZ495jHXiY2J6DWYkJXKrBCQRBS+u+hmlnhRfC5b0Uq1poZs0FLVMiDAmbw==",
 			"license": "MIT",
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
@@ -4586,26 +4586,26 @@
 				"url": "https://github.com/sponsors/Boshen"
 			},
 			"optionalDependencies": {
-				"@oxc-minify/binding-android-arm-eabi": "0.140.0",
-				"@oxc-minify/binding-android-arm64": "0.140.0",
-				"@oxc-minify/binding-darwin-arm64": "0.140.0",
-				"@oxc-minify/binding-darwin-x64": "0.140.0",
-				"@oxc-minify/binding-freebsd-x64": "0.140.0",
-				"@oxc-minify/binding-linux-arm-gnueabihf": "0.140.0",
-				"@oxc-minify/binding-linux-arm-musleabihf": "0.140.0",
-				"@oxc-minify/binding-linux-arm64-gnu": "0.140.0",
-				"@oxc-minify/binding-linux-arm64-musl": "0.140.0",
-				"@oxc-minify/binding-linux-ppc64-gnu": "0.140.0",
-				"@oxc-minify/binding-linux-riscv64-gnu": "0.140.0",
-				"@oxc-minify/binding-linux-riscv64-musl": "0.140.0",
-				"@oxc-minify/binding-linux-s390x-gnu": "0.140.0",
-				"@oxc-minify/binding-linux-x64-gnu": "0.140.0",
-				"@oxc-minify/binding-linux-x64-musl": "0.140.0",
-				"@oxc-minify/binding-openharmony-arm64": "0.140.0",
-				"@oxc-minify/binding-wasm32-wasi": "0.140.0",
-				"@oxc-minify/binding-win32-arm64-msvc": "0.140.0",
-				"@oxc-minify/binding-win32-ia32-msvc": "0.140.0",
-				"@oxc-minify/binding-win32-x64-msvc": "0.140.0"
+				"@oxc-minify/binding-android-arm-eabi": "0.141.0",
+				"@oxc-minify/binding-android-arm64": "0.141.0",
+				"@oxc-minify/binding-darwin-arm64": "0.141.0",
+				"@oxc-minify/binding-darwin-x64": "0.141.0",
+				"@oxc-minify/binding-freebsd-x64": "0.141.0",
+				"@oxc-minify/binding-linux-arm-gnueabihf": "0.141.0",
+				"@oxc-minify/binding-linux-arm-musleabihf": "0.141.0",
+				"@oxc-minify/binding-linux-arm64-gnu": "0.141.0",
+				"@oxc-minify/binding-linux-arm64-musl": "0.141.0",
+				"@oxc-minify/binding-linux-ppc64-gnu": "0.141.0",
+				"@oxc-minify/binding-linux-riscv64-gnu": "0.141.0",
+				"@oxc-minify/binding-linux-riscv64-musl": "0.141.0",
+				"@oxc-minify/binding-linux-s390x-gnu": "0.141.0",
+				"@oxc-minify/binding-linux-x64-gnu": "0.141.0",
+				"@oxc-minify/binding-linux-x64-musl": "0.141.0",
+				"@oxc-minify/binding-openharmony-arm64": "0.141.0",
+				"@oxc-minify/binding-wasm32-wasi": "0.141.0",
+				"@oxc-minify/binding-win32-arm64-msvc": "0.141.0",
+				"@oxc-minify/binding-win32-ia32-msvc": "0.141.0",
+				"@oxc-minify/binding-win32-x64-msvc": "0.141.0"
 			}
 		},
 		"node_modules/p-limit": {
@@ -4821,9 +4821,9 @@
 			}
 		},
 		"node_modules/prettier": {
-			"version": "3.9.5",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.5.tgz",
-			"integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
+			"version": "3.9.6",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+			"integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -5195,9 +5195,9 @@
 			}
 		},
 		"node_modules/sinon": {
-			"version": "22.0.0",
-			"resolved": "https://registry.npmjs.org/sinon/-/sinon-22.0.0.tgz",
-			"integrity": "sha512-sq/6DpdXOrLyfbKlXLg/Usc7xu8YXPeLkOFZRvA3bNUSA2lhbrZ06yuXbH1fkzBPCbz9O10+7hznzUsjaYNm0Q==",
+			"version": "22.1.0",
+			"resolved": "https://registry.npmjs.org/sinon/-/sinon-22.1.0.tgz",
+			"integrity": "sha512-n1ajF2rBWMTtEwbKcw4UdFg4nCnDdq/U6RDoxtOd7oapOlRoJ5ynwFx60owROyhDpA9QhMZi0pCO/xtmwFjG7w==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -164,12 +164,12 @@
 		"prepare": "husky"
 	},
 	"devDependencies": {
-		"@types/mocha": "^10.0.6",
+		"@types/mocha": "^10.0.10",
 		"@types/node": "^26.1.1",
 		"@types/sinon": "^22.0.0",
 		"@types/vscode": "^1.125.0",
-		"@typescript-eslint/eslint-plugin": "^8.64.0",
-		"@typescript-eslint/parser": "^8.58.0",
+		"@typescript-eslint/eslint-plugin": "^8.65.0",
+		"@typescript-eslint/parser": "^8.65.0",
 		"@vscode/l10n-dev": "^0.0.35",
 		"@vscode/test-cli": "^0.0.15",
 		"@vscode/test-electron": "^3.0.0",
@@ -179,8 +179,8 @@
 		"eslint-plugin-tsdoc": "^0.5.2",
 		"husky": "^9.1.7",
 		"mocha": "^11.7.6",
-		"prettier": "^3.9.5",
-		"sinon": "^22.0.0",
+		"prettier": "^3.9.6",
+		"sinon": "^22.1.0",
 		"ts-loader": "^9.6.2",
 		"typescript": "^6.0.3",
 		"webpack": "^5.108.4",
@@ -199,8 +199,8 @@
 		"@sinonjs/fake-timers": "15.1.1"
 	},
 	"dependencies": {
-		"detect-libc": "^2.0.4",
+		"detect-libc": "^2.1.2",
 		"lightningcss": "^1.33.0",
-		"oxc-minify": "^0.140.0"
+		"oxc-minify": "^0.141.0"
 	}
 }


### PR DESCRIPTION
## Summary
Update 7 minor/patch dependencies to their latest versions. Major version bumps (eslint 9→10, typescript 6→7) deferred for separate evaluation.

## Changes Made
- `@types/mocha` ^10.0.6 → ^10.0.10 (patch)
- `@typescript-eslint/eslint-plugin` ^8.64.0 → ^8.65.0 (minor)
- `@typescript-eslint/parser` ^8.58.0 → ^8.65.0 (minor)
- `detect-libc` ^2.0.4 → ^2.1.2 (minor)
- `oxc-minify` ^0.140.0 → ^0.141.0 (minor)
- `prettier` ^3.9.5 → ^3.9.6 (patch)
- `sinon` ^22.0.0 → ^22.1.0 (minor)

## Type of Change
- [x] 🔧 Refactoring

## Testing
- [x] ESLint passes
- [x] TypeScript type-check passes (`tsc --noEmit`)
- [x] Webpack production build succeeds

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests pass locally